### PR TITLE
feat: add danmaku font family/weight settings in advanced settings

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -32,7 +32,7 @@
     "scrollSpeed": 0.95,
     "danmakuTimeOffset": 0,
     "danmakuFontFamily": "",
-    "danmakuFontWeight": "",
+    "danmakuFontWeight": "400",
     "dandanplayAppId": "",
     "dandanplayAppSecret": "",
     "dandanplayAutoNetwork": true,

--- a/Info.json
+++ b/Info.json
@@ -31,6 +31,8 @@
     "commentLimit": 0,
     "scrollSpeed": 0.95,
     "danmakuTimeOffset": 0,
+    "danmakuFontFamily": "",
+    "danmakuFontWeight": "",
     "dandanplayAppId": "",
     "dandanplayAppSecret": "",
     "dandanplayAutoNetwork": true,

--- a/main.js
+++ b/main.js
@@ -20,6 +20,8 @@ var strokeInversionColor = preferences.get("strokeInversionColor") || '#ffffff';
 var commentLimit = preferences.get("commentLimit") !== undefined ? preferences.get("commentLimit") : 0;
 var scrollSpeed = preferences.get("scrollSpeed") !== undefined ? preferences.get("scrollSpeed") : 0.95;
 var danmakuTimeOffsetSec = preferences.get("danmakuTimeOffset") !== undefined ? preferences.get("danmakuTimeOffset") : 0;
+var danmakuFontFamily = preferences.get("danmakuFontFamily") || "";
+var danmakuFontWeight = preferences.get("danmakuFontWeight") || "";
 var currentPlaybackSpeed = 1.0;
 var overlayReady = false;
 var preferencesSyncTimer = null;
@@ -96,6 +98,18 @@ function applyDanmakuOffset(offsetSec) {
     overlay.postMessage("set-danmaku-offset", { offset: danmakuTimeOffsetSec });
   }
   sidebar.postMessage("danmaku-state", { danmakuTimeOffsetSec: danmakuTimeOffsetSec });
+}
+
+function applyDanmakuFont(fontFamily, fontWeight) {
+  danmakuFontFamily = fontFamily || "";
+  danmakuFontWeight = fontWeight || "";
+  preferences.set("danmakuFontFamily", danmakuFontFamily);
+  preferences.set("danmakuFontWeight", danmakuFontWeight);
+  syncPreferencesSoon();
+  if (overlayReady) {
+    overlay.postMessage("set-danmaku-font", { fontFamily: danmakuFontFamily, fontWeight: danmakuFontWeight });
+  }
+  sidebar.postMessage("danmaku-state", { danmakuFontFamily: danmakuFontFamily, danmakuFontWeight: danmakuFontWeight });
 }
 
 function findDanmakuFileByPath(path) {
@@ -342,6 +356,8 @@ function applyDanmakuFilter(offset, limit) {
     commentLimit: commentLimit,
     scrollSpeed: scrollSpeed,
     danmakuTimeOffsetSec: danmakuTimeOffsetSec,
+    danmakuFontFamily: danmakuFontFamily,
+    danmakuFontWeight: danmakuFontWeight,
     preservePosition: true,
   });
   sendDanmakuFilterInfo();
@@ -1105,6 +1121,8 @@ function markOverlayReady() {
     commentLimit: commentLimit,
     scrollSpeed: scrollSpeed,
     danmakuTimeOffsetSec: danmakuTimeOffsetSec,
+    danmakuFontFamily: danmakuFontFamily,
+    danmakuFontWeight: danmakuFontWeight,
     danmakuForceSimplified: danmakuForceSimplified
   });
 
@@ -1328,6 +1346,10 @@ function registerSidebarHandlers() {
     applyDanmakuOffset(data.offset);
   });
 
+  sidebar.onMessage("set-danmaku-font", function (data) {
+    applyDanmakuFont(data.fontFamily, data.fontWeight);
+  });
+
   sidebar.onMessage("adjust-danmaku-offset", function (data) {
     var delta = parseFloat(data.delta);
     if (isNaN(delta)) delta = 0;
@@ -1370,6 +1392,8 @@ function registerSidebarHandlers() {
       commentLimit: commentLimit,
       scrollSpeed: scrollSpeed,
       danmakuTimeOffsetSec: danmakuTimeOffsetSec,
+      danmakuFontFamily: danmakuFontFamily,
+      danmakuFontWeight: danmakuFontWeight,
       danmakuForceSimplified: danmakuForceSimplified,
       danmakuFileType: currentDanmakuStatus.fileType,
       danmakuFileName: currentDanmakuStatus.fileName,

--- a/main.js
+++ b/main.js
@@ -21,7 +21,7 @@ var commentLimit = preferences.get("commentLimit") !== undefined ? preferences.g
 var scrollSpeed = preferences.get("scrollSpeed") !== undefined ? preferences.get("scrollSpeed") : 0.95;
 var danmakuTimeOffsetSec = preferences.get("danmakuTimeOffset") !== undefined ? preferences.get("danmakuTimeOffset") : 0;
 var danmakuFontFamily = preferences.get("danmakuFontFamily") || "";
-var danmakuFontWeight = preferences.get("danmakuFontWeight") || "";
+var danmakuFontWeight = preferences.get("danmakuFontWeight") || "400";
 var currentPlaybackSpeed = 1.0;
 var overlayReady = false;
 var preferencesSyncTimer = null;

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -12,6 +12,8 @@ let strokeWidth = 2.8;
 let commentLimit = 0;
 let scrollSpeed = 0.95;
 let danmakuTimeOffsetSec = 0;
+let danmakuFontFamily = "";
+let danmakuFontWeight = "";
 
 let niconiComments = null;
 let nicoRawData = null;
@@ -155,6 +157,16 @@ function disposeCanvasRenderer() {
   niconiComments = null;
 }
 
+function buildDanmakuFontConfig() {
+  if (!danmakuFontFamily) return undefined;
+  var weight = danmakuFontWeight ? parseInt(danmakuFontWeight, 10) : 400;
+  if (isNaN(weight) || weight < 100 || weight > 900) weight = 400;
+  var item = { font: danmakuFontFamily, offset: 0, weight: weight };
+  return {
+    html5: { gothic: item, mincho: item, defont: item },
+  };
+}
+
 function initCanvasRenderer(data) {
   const canvas = document.getElementById('niconicomments-canvas');
   if (!canvas || typeof NiconiComments === 'undefined') return;
@@ -175,6 +187,7 @@ function initCanvasRenderer(data) {
       contextLineWidth: { html5: strokeWidth, flash: strokeWidth },
       commentLimit: commentLimit > 0 ? commentLimit : undefined,
       nakaCommentSpeedOffset: scrollSpeed,
+      fonts: buildDanmakuFontConfig(),
     },
   });
   nicoRawData = data;
@@ -245,6 +258,8 @@ iina.onMessage("load-danmaku", (data) => {
   if (data.commentLimit !== undefined) commentLimit = data.commentLimit;
   if (data.scrollSpeed !== undefined) scrollSpeed = data.scrollSpeed;
   if (data.danmakuTimeOffsetSec !== undefined) danmakuTimeOffsetSec = Number(data.danmakuTimeOffsetSec) || 0;
+  if (data.danmakuFontFamily !== undefined) danmakuFontFamily = data.danmakuFontFamily || "";
+  if (data.danmakuFontWeight !== undefined) danmakuFontWeight = data.danmakuFontWeight || "";
   if (data.opacity !== undefined) {
     canvasOpacity = data.opacity;
     const canvas = document.getElementById('niconicomments-canvas');
@@ -403,6 +418,12 @@ iina.onMessage("set-danmaku-offset", (data) => {
   }
 });
 
+iina.onMessage("set-danmaku-font", (data) => {
+  if (data.fontFamily !== undefined) danmakuFontFamily = data.fontFamily || "";
+  if (data.fontWeight !== undefined) danmakuFontWeight = data.fontWeight || "";
+  if (nicoRawData) initCanvasRenderer(nicoRawData);
+});
+
 iina.onMessage("clear-danmaku", () => {
   destroyCanvasRenderer();
   const cssContainer = document.querySelector('[data-dm-css-container]');
@@ -431,6 +452,8 @@ iina.onMessage("apply-settings", (data) => {
   if (data.commentLimit !== undefined) commentLimit = data.commentLimit;
   if (data.scrollSpeed !== undefined) scrollSpeed = data.scrollSpeed;
   if (data.danmakuTimeOffsetSec !== undefined) danmakuTimeOffsetSec = Number(data.danmakuTimeOffsetSec) || 0;
+  if (data.danmakuFontFamily !== undefined) danmakuFontFamily = data.danmakuFontFamily || "";
+  if (data.danmakuFontWeight !== undefined) danmakuFontWeight = data.danmakuFontWeight || "";
   if (data.danmakuForceSimplified !== undefined) {
     updateSimplifiedConverter(data.danmakuForceSimplified);
   }

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -157,13 +157,33 @@ function disposeCanvasRenderer() {
   niconiComments = null;
 }
 
+var DEFAULT_DANMAKU_FONT_STACKS = {
+  gothic: { font: '"游ゴシック体", "游ゴシック", "Yu Gothic", YuGothic, yugothic, YuGo-Medium, "Hiragino Sans", HiraginoSans', offset: -0.04, weight: 400 },
+  mincho: { font: '"游明朝体", "游明朝", "Yu Mincho", YuMincho, yumincho, YuMin-Medium, "Hiragino Mincho ProN", HiraMinProN, "Hiragino Mincho ProN W3", HiraMinProN-W3', offset: -0.01, weight: 400 },
+  defont: { font: '"Hiragino Sans", "ヒラギノ角ゴシック", HiraginoSans', offset: -0.05, weight: 600 },
+};
+
 function buildDanmakuFontConfig() {
-  if (!danmakuFontFamily) return undefined;
   var weight = danmakuFontWeight ? parseInt(danmakuFontWeight, 10) : 400;
   if (isNaN(weight) || weight < 100 || weight > 900) weight = 400;
-  var item = { font: danmakuFontFamily, offset: 0, weight: weight };
+  var mk = function (type) {
+    var def = DEFAULT_DANMAKU_FONT_STACKS[type];
+    return {
+      font: danmakuFontFamily || def.font,
+      offset: danmakuFontFamily ? 0 : def.offset,
+      weight: weight,
+    };
+  };
   return {
-    html5: { gothic: item, mincho: item, defont: item },
+    flash: {
+      gulim: 'normal 600 [size]px gulim, ' + (danmakuFontFamily || DEFAULT_DANMAKU_FONT_STACKS.gothic.font) + ', Arial',
+      simsun: 'normal 400 [size]px simsun, batang, "PMingLiU", MingLiU-ExtB, ' + (danmakuFontFamily || DEFAULT_DANMAKU_FONT_STACKS.mincho.font) + ', Arial',
+    },
+    html5: {
+      gothic: mk('gothic'),
+      mincho: mk('mincho'),
+      defont: mk('defont'),
+    },
   };
 }
 

--- a/sidebar/index.html
+++ b/sidebar/index.html
@@ -132,15 +132,27 @@
         <h3 class="section-title" data-i18n="danmaku_font" style="margin-top:10px">Font</h3>
         <div class="control-row">
           <span class="toggle-label" data-i18n="danmaku_font_family">Font Family</span>
-          <select id="danmaku-font-select" data-clickable style="margin-left:auto;max-width:170px;padding:4px;border-radius:4px;border:1px solid var(--separator);background:var(--secondary-system-fill);color:var(--label)">
+          <select id="danmaku-font-select" data-clickable style="margin-left:auto;max-width:190px;padding:4px;border-radius:4px;border:1px solid var(--separator);background:var(--secondary-system-fill);color:var(--label)">
             <option value="">Default</option>
-            <option value="gothic">Gothic (Hiragino)</option>
-            <option value="mincho">Mincho (Hiragino)</option>
-            <option value="maru">Maru Gothic</option>
-            <option value="songti">Songti / SimSun</option>
-            <option value="sans">sans-serif</option>
-            <option value="serif">serif</option>
-            <option value="mono">monospace</option>
+            <optgroup label="Japanese">
+              <option value="gothic">Hiragino Gothic</option>
+              <option value="mincho">Hiragino Mincho</option>
+              <option value="maru">Hiragino Maru Gothic</option>
+              <option value="yugothic">Yu Gothic</option>
+              <option value="yumincho">Yu Mincho</option>
+            </optgroup>
+            <optgroup label="Chinese">
+              <option value="pingfang">PingFang SC</option>
+              <option value="songti">Songti SC</option>
+              <option value="kaiti">KaiTi</option>
+              <option value="yahei">Microsoft YaHei</option>
+              <option value="simsun">SimSun</option>
+            </optgroup>
+            <optgroup label="Generic">
+              <option value="sans">sans-serif</option>
+              <option value="serif">serif</option>
+              <option value="mono">monospace</option>
+            </optgroup>
             <option value="custom">Custom…</option>
           </select>
         </div>
@@ -150,7 +162,7 @@
         </div>
         <h3 class="section-title" data-i18n="danmaku_font_weight" style="margin-top:10px">Weight</h3>
         <div class="control-row">
-          <input type="range" id="danmaku-font-weight-slider" data-clickable min="100" max="900" step="100" value="400" class="slider" />
+          <input type="range" id="danmaku-font-weight-slider" data-clickable min="100" max="900" step="50" value="400" class="slider" />
           <span id="danmaku-font-weight-value" class="value-text">400</span>
         </div>
         <h3 class="section-title" data-i18n="comment_limit" style="margin-top:10px">Comment Limit</h3>

--- a/sidebar/index.html
+++ b/sidebar/index.html
@@ -129,6 +129,37 @@
         <div class="control-row" style="margin-top:6px">
           <span id="danmaku-offset-hint" class="value-text" data-i18n="danmaku_offset_hint">A: rewind • D: advance</span>
         </div>
+        <h3 class="section-title" data-i18n="danmaku_font" style="margin-top:10px">Font</h3>
+        <div class="control-row">
+          <span class="toggle-label" data-i18n="danmaku_font_family">Font Family</span>
+          <select id="danmaku-font-select" data-clickable style="margin-left:auto;max-width:170px;padding:4px;border-radius:4px;border:1px solid var(--separator);background:var(--secondary-system-fill);color:var(--label)">
+            <option value="">Default</option>
+            <option value="gothic">Gothic (Hiragino)</option>
+            <option value="mincho">Mincho (Hiragino)</option>
+            <option value="maru">Maru Gothic</option>
+            <option value="songti">Songti / SimSun</option>
+            <option value="sans">sans-serif</option>
+            <option value="serif">serif</option>
+            <option value="mono">monospace</option>
+            <option value="custom">Custom…</option>
+          </select>
+        </div>
+        <div class="control-row" id="danmaku-font-custom-row" style="display:none;margin-top:6px">
+          <span class="toggle-label" data-i18n="danmaku_font_custom">Custom Font</span>
+          <input type="text" id="danmaku-font-custom" placeholder="'Helvetica Neue', sans-serif" style="margin-left:auto;width:150px;padding:4px;border-radius:4px;border:1px solid var(--separator);background:var(--secondary-system-fill);color:var(--label)" />
+        </div>
+        <div class="control-row" style="margin-top:6px">
+          <span class="toggle-label" data-i18n="danmaku_font_weight">Weight</span>
+          <select id="danmaku-font-weight" data-clickable style="margin-left:auto;padding:4px;border-radius:4px;border:1px solid var(--separator);background:var(--secondary-system-fill);color:var(--label)">
+            <option value="">Default</option>
+            <option value="100">100 Thin</option>
+            <option value="300">300 Light</option>
+            <option value="400">400 Regular</option>
+            <option value="500">500 Medium</option>
+            <option value="700">700 Bold</option>
+            <option value="900">900 Black</option>
+          </select>
+        </div>
         <h3 class="section-title" data-i18n="comment_limit" style="margin-top:10px">Comment Limit</h3>
         <div class="control-row">
           <input type="range" id="comment-limit-slider" data-clickable min="0" max="200" step="10" value="0" class="slider" />

--- a/sidebar/index.html
+++ b/sidebar/index.html
@@ -148,17 +148,10 @@
           <span class="toggle-label" data-i18n="danmaku_font_custom">Custom Font</span>
           <input type="text" id="danmaku-font-custom" placeholder="'Helvetica Neue', sans-serif" style="margin-left:auto;width:150px;padding:4px;border-radius:4px;border:1px solid var(--separator);background:var(--secondary-system-fill);color:var(--label)" />
         </div>
-        <div class="control-row" style="margin-top:6px">
-          <span class="toggle-label" data-i18n="danmaku_font_weight">Weight</span>
-          <select id="danmaku-font-weight" data-clickable style="margin-left:auto;padding:4px;border-radius:4px;border:1px solid var(--separator);background:var(--secondary-system-fill);color:var(--label)">
-            <option value="">Default</option>
-            <option value="100">100 Thin</option>
-            <option value="300">300 Light</option>
-            <option value="400">400 Regular</option>
-            <option value="500">500 Medium</option>
-            <option value="700">700 Bold</option>
-            <option value="900">900 Black</option>
-          </select>
+        <h3 class="section-title" data-i18n="danmaku_font_weight" style="margin-top:10px">Weight</h3>
+        <div class="control-row">
+          <input type="range" id="danmaku-font-weight-slider" data-clickable min="100" max="900" step="100" value="400" class="slider" />
+          <span id="danmaku-font-weight-value" class="value-text">400</span>
         </div>
         <h3 class="section-title" data-i18n="comment_limit" style="margin-top:10px">Comment Limit</h3>
         <div class="control-row">

--- a/sidebar/index.js
+++ b/sidebar/index.js
@@ -17,6 +17,10 @@ var speedSlider = document.getElementById("speed-slider");
 var speedValue = document.getElementById("speed-value");
 var offsetInput = document.getElementById("danmaku-offset-input");
 var offsetHint = document.getElementById("danmaku-offset-hint");
+var fontSelect = document.getElementById("danmaku-font-select");
+var fontCustomRow = document.getElementById("danmaku-font-custom-row");
+var fontCustomInput = document.getElementById("danmaku-font-custom");
+var fontWeightSelect = document.getElementById("danmaku-font-weight");
 var filterSection = document.getElementById("danmaku-filter-section");
 var filterDateNew = document.getElementById("danmaku-filter-date-new");
 var filterDateOld = document.getElementById("danmaku-filter-date-old");
@@ -82,6 +86,8 @@ var state = {
   commentLimit: 0,
   scrollSpeed: 0.95,
   danmakuOffsetSeconds: 0,
+  danmakuFontFamily: "",
+  danmakuFontWeight: "",
   nicoJsonTotalCount: 0,
   danmakuFilterOffset: 0,
   danmakuFilterLimit: 0,
@@ -261,6 +267,10 @@ var i18n = {
     advanced: "Advanced",
     danmaku_offset: "Danmaku Offset (s)",
     danmaku_offset_hint: "A: rewind • D: advance",
+    danmaku_font: "Font",
+    danmaku_font_family: "Font Family",
+    danmaku_font_custom: "Custom Font",
+    danmaku_font_weight: "Weight",
     comment_limit: "Comment Limit",
     stroke_color: "Stroke Color",
     stroke_inversion: "Invert Color",
@@ -311,6 +321,10 @@ var i18n = {
     advanced: "\u9ad8\u5ea6\u306a\u8a2d\u5b9a",
     danmaku_offset: "\u5f3e\u5e55\u6642\u9593\u30aa\u30d5\u30bb\u30c3\u30c8 (\u79d2)",
     danmaku_offset_hint: "A: \u5de5\u5e30\u3057\u3082\u3069\u3057 • D: \u9032\u3080",
+    danmaku_font: "\u30d5\u30a9\u30f3\u30c8",
+    danmaku_font_family: "\u30d5\u30a9\u30f3\u30c8",
+    danmaku_font_custom: "\u30ab\u30b9\u30bf\u30e0\u30d5\u30a9\u30f3\u30c8",
+    danmaku_font_weight: "\u592a\u3055",
     comment_limit: "\u30b3\u30e1\u30f3\u30c8\u5236\u9650",
     stroke_color: "\u7e01\u53d6\u308a\u306e\u8272",
     stroke_inversion: "\u9006\u7e01\u53d6\u308a\u8272",
@@ -361,6 +375,10 @@ var i18n = {
     advanced: "\u9ad8\u7ea7\u8bbe\u7f6e",
     danmaku_offset: "\u5f39\u5e55\u65f6\u95f4\u504f\u79fb (\u79d2)",
     danmaku_offset_hint: "A: \u5feb\u9000 • D: \u5feb\u8fdb",
+    danmaku_font: "\u5b57\u4f53",
+    danmaku_font_family: "\u5b57\u4f53",
+    danmaku_font_custom: "\u81ea\u5b9a\u4e49\u5b57\u4f53",
+    danmaku_font_weight: "\u7c97\u7ec6",
     comment_limit: "\u5f39\u5e55\u4e0a\u9650",
     stroke_color: "\u63cf\u8fb9\u989c\u8272",
     stroke_inversion: "\u53cd\u8272\u63cf\u8fb9",
@@ -434,6 +452,37 @@ function updateOffsetUI() {
   }
 }
 
+var FONT_PRESETS = {
+  "": "",
+  gothic: '"Hiragino Kaku Gothic ProN", "Hiragino Sans", "ヒラギノ角ゴ ProN", sans-serif',
+  mincho: '"Hiragino Mincho ProN", "ヒラギノ明朝 ProN", serif',
+  maru: '"Hiragino Maru Gothic ProN", "ヒラギノ丸ゴ ProN", sans-serif',
+  songti: '"Songti SC", "SimSun", "宋体", serif',
+  sans: "sans-serif",
+  serif: "serif",
+  mono: "monospace"
+};
+
+function fontFamilyToPresetKey(family) {
+  for (var key in FONT_PRESETS) {
+    if (FONT_PRESETS.hasOwnProperty(key) && key !== "" && FONT_PRESETS[key] === family) return key;
+  }
+  return "custom";
+}
+
+function updateFontUI() {
+  if (!fontSelect || !fontCustomInput || !fontCustomRow || !fontWeightSelect) return;
+  var key = state.danmakuFontFamily ? fontFamilyToPresetKey(state.danmakuFontFamily) : "";
+  fontSelect.value = key;
+  if (key === "custom") {
+    fontCustomRow.style.display = "";
+    fontCustomInput.value = state.danmakuFontFamily;
+  } else {
+    fontCustomRow.style.display = "none";
+  }
+  fontWeightSelect.value = state.danmakuFontWeight;
+}
+
 function updateUI() {
   var hasFiles = fileListState.xmlFiles.length > 0 || fileListState.jsonFiles.length > 0 || fileListState.unknownFiles.length > 0;
   var hasDanmaku = state.danmakuLoaded || hasFiles;
@@ -457,6 +506,7 @@ function updateUI() {
   if (canvasRendererToggle) canvasRendererToggle.checked = state.useCanvasRenderer;
   if (danmakuForceSimplifiedToggle) danmakuForceSimplifiedToggle.checked = state.danmakuForceSimplified; 
   updateOffsetUI();
+  updateFontUI();
   updateFilterUI();
 }
 
@@ -615,6 +665,35 @@ if (offsetInput) {
     state.danmakuOffsetSeconds = val;
     iina.postMessage("set-danmaku-offset", { offset: state.danmakuOffsetSeconds });
     updateOffsetUI();
+  });
+}
+
+if (fontSelect) {
+  fontSelect.addEventListener("change", function () {
+    var key = fontSelect.value;
+    var family = FONT_PRESETS[key] !== undefined ? FONT_PRESETS[key] : "";
+    if (key === "custom") {
+      family = fontCustomInput.value.trim();
+      fontCustomRow.style.display = "";
+    } else {
+      fontCustomRow.style.display = "none";
+    }
+    state.danmakuFontFamily = family;
+    iina.postMessage("set-danmaku-font", { fontFamily: family, fontWeight: state.danmakuFontWeight });
+  });
+}
+
+if (fontCustomInput) {
+  fontCustomInput.addEventListener("input", function () {
+    state.danmakuFontFamily = fontCustomInput.value.trim();
+    iina.postMessage("set-danmaku-font", { fontFamily: state.danmakuFontFamily, fontWeight: state.danmakuFontWeight });
+  });
+}
+
+if (fontWeightSelect) {
+  fontWeightSelect.addEventListener("change", function () {
+    state.danmakuFontWeight = fontWeightSelect.value;
+    iina.postMessage("set-danmaku-font", { fontFamily: state.danmakuFontFamily, fontWeight: state.danmakuFontWeight });
   });
 }
 
@@ -808,6 +887,8 @@ iina.onMessage("danmaku-state", function (data) {
   if (data.commentLimit !== undefined) state.commentLimit = data.commentLimit;
   if (data.scrollSpeed !== undefined) state.scrollSpeed = data.scrollSpeed;
   if (data.danmakuTimeOffsetSec !== undefined) state.danmakuOffsetSeconds = data.danmakuTimeOffsetSec;
+  if (data.danmakuFontFamily !== undefined) state.danmakuFontFamily = data.danmakuFontFamily;
+  if (data.danmakuFontWeight !== undefined) state.danmakuFontWeight = data.danmakuFontWeight;
   if (data.danmakuForceSimplified !== undefined) state.danmakuForceSimplified = !!data.danmakuForceSimplified;
   if (data.danmakuFileType !== undefined) state.danmakuType = data.danmakuFileType;
   if (data.danmakuFileName !== undefined) state.danmakuFileName = data.danmakuFileName;

--- a/sidebar/index.js
+++ b/sidebar/index.js
@@ -458,7 +458,13 @@ var FONT_PRESETS = {
   gothic: '"Hiragino Kaku Gothic ProN", "Hiragino Sans", "ヒラギノ角ゴ ProN", sans-serif',
   mincho: '"Hiragino Mincho ProN", "ヒラギノ明朝 ProN", serif',
   maru: '"Hiragino Maru Gothic ProN", "ヒラギノ丸ゴ ProN", sans-serif',
+  yugothic: '"Yu Gothic", YuGothic, yugothic, "Hiragino Sans", sans-serif',
+  yumincho: '"Yu Mincho", YuMincho, yumincho, "Hiragino Mincho ProN", serif',
+  pingfang: '"PingFang SC", "PingFang TC", "Hiragino Sans GB", sans-serif',
   songti: '"Songti SC", "SimSun", "宋体", serif',
+  kaiti: '"Kaiti SC", "KaiTi", "楷体", serif',
+  yahei: '"Microsoft YaHei", "微软雅黑", "PingFang SC", sans-serif',
+  simsun: '"SimSun", "宋体", serif',
   sans: "sans-serif",
   serif: "serif",
   mono: "monospace"
@@ -677,15 +683,20 @@ if (offsetInput) {
 if (fontSelect) {
   fontSelect.addEventListener("change", function () {
     var key = fontSelect.value;
-    var family = FONT_PRESETS[key] !== undefined ? FONT_PRESETS[key] : "";
     if (key === "custom") {
-      family = fontCustomInput.value.trim();
       fontCustomRow.style.display = "";
+      fontCustomInput.focus();
+      var customFamily = fontCustomInput.value.trim();
+      if (customFamily) {
+        state.danmakuFontFamily = customFamily;
+        iina.postMessage("set-danmaku-font", { fontFamily: customFamily, fontWeight: state.danmakuFontWeight });
+      }
     } else {
       fontCustomRow.style.display = "none";
+      var preset = FONT_PRESETS[key] !== undefined ? FONT_PRESETS[key] : "";
+      state.danmakuFontFamily = preset;
+      iina.postMessage("set-danmaku-font", { fontFamily: preset, fontWeight: state.danmakuFontWeight });
     }
-    state.danmakuFontFamily = family;
-    iina.postMessage("set-danmaku-font", { fontFamily: family, fontWeight: state.danmakuFontWeight });
   });
 }
 

--- a/sidebar/index.js
+++ b/sidebar/index.js
@@ -20,7 +20,8 @@ var offsetHint = document.getElementById("danmaku-offset-hint");
 var fontSelect = document.getElementById("danmaku-font-select");
 var fontCustomRow = document.getElementById("danmaku-font-custom-row");
 var fontCustomInput = document.getElementById("danmaku-font-custom");
-var fontWeightSelect = document.getElementById("danmaku-font-weight");
+var fontWeightSlider = document.getElementById("danmaku-font-weight-slider");
+var fontWeightValue = document.getElementById("danmaku-font-weight-value");
 var filterSection = document.getElementById("danmaku-filter-section");
 var filterDateNew = document.getElementById("danmaku-filter-date-new");
 var filterDateOld = document.getElementById("danmaku-filter-date-old");
@@ -87,7 +88,7 @@ var state = {
   scrollSpeed: 0.95,
   danmakuOffsetSeconds: 0,
   danmakuFontFamily: "",
-  danmakuFontWeight: "",
+  danmakuFontWeight: "400",
   nicoJsonTotalCount: 0,
   danmakuFilterOffset: 0,
   danmakuFilterLimit: 0,
@@ -471,7 +472,7 @@ function fontFamilyToPresetKey(family) {
 }
 
 function updateFontUI() {
-  if (!fontSelect || !fontCustomInput || !fontCustomRow || !fontWeightSelect) return;
+  if (!fontSelect || !fontCustomInput || !fontCustomRow) return;
   var key = state.danmakuFontFamily ? fontFamilyToPresetKey(state.danmakuFontFamily) : "";
   fontSelect.value = key;
   if (key === "custom") {
@@ -480,7 +481,12 @@ function updateFontUI() {
   } else {
     fontCustomRow.style.display = "none";
   }
-  fontWeightSelect.value = state.danmakuFontWeight;
+  if (fontWeightSlider) {
+    fontWeightSlider.value = state.danmakuFontWeight || "400";
+  }
+  if (fontWeightValue) {
+    fontWeightValue.textContent = fontWeightSlider ? fontWeightSlider.value : "400";
+  }
 }
 
 function updateUI() {
@@ -690,9 +696,10 @@ if (fontCustomInput) {
   });
 }
 
-if (fontWeightSelect) {
-  fontWeightSelect.addEventListener("change", function () {
-    state.danmakuFontWeight = fontWeightSelect.value;
+if (fontWeightSlider) {
+  fontWeightSlider.addEventListener("input", function () {
+    state.danmakuFontWeight = fontWeightSlider.value;
+    if (fontWeightValue) fontWeightValue.textContent = fontWeightSlider.value;
     iina.postMessage("set-danmaku-font", { fontFamily: state.danmakuFontFamily, fontWeight: state.danmakuFontWeight });
   });
 }


### PR DESCRIPTION
## 功能

侧边栏 → 高级设置新增 **Font** 区,可自定义弹幕字体和粗细:

- **Font Family**:13 个预设(日文系 Hiragino/Yu、中文系苹方/宋体/楷体/雅黑、通用 sans-serif/serif/monospace)+ 自定义输入
- **Weight**:slider 100~900(步进 50),与其他设置控件风格统一
- 设置持久化到 preferences,重启保留

## 实现

引擎(niconicomments)原生支持通过 init config 的 `fonts.html5.<gothic|mincho|defont>` 指定字体(CSS/Canvas 双模式同路径,见 `applyFont`)。overlay 侧 `buildDanmakuFontConfig()` 生成完整 config:

- **始终传完整 `{ flash, html5 }` 结构** —— 引擎 `isValidFonts` 校验要求两组键齐全,缺失会导致 `InvalidOptionError` 抛出、渲染器无法初始化(弹幕消失)
- 字体为空时回退引擎默认字体栈(Yu Gothic / Yu Mincho / Hiragino Sans,含默认 offset),外观与默认一致
- 改动时重建渲染器即时生效,无需重载弹幕

数据流:sidebar `set-danmaku-font` → main.js `applyDanmakuFont`(持久化 + 转发)→ overlay 更新变量并重建渲染器。

## 改动文件

- `Info.json`:新增 `danmakuFontFamily` / `danmakuFontWeight` 默认值
- `main.js`:preferences 读写、消息转发、状态同步
- `overlay/main.js`:字体 config 构建与渲染器重建
- `sidebar/index.html` / `sidebar/index.js`:UI、预设、i18n(EN/JA/中文)

## 验证

- 真机实测:字体切换、粗细调整、重启保留均正常
- 引擎 `isValidFonts` 校验逻辑模拟通过