### PR TITLE
feat: fixed-comment progressive combo + sidebar owner rows + per-video offset

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -29,7 +29,6 @@
     "strokeWidth": 2.8,
     "commentLimit": 0,
     "scrollSpeed": 1.0,
-    "danmakuTimeOffset": 0,
     "danmakuFontFamily": "",
     "danmakuFontWeight": "400",
     "dandanplayAppId": "",

--- a/main.js
+++ b/main.js
@@ -1003,16 +1003,18 @@ function buildDanmakuBrowserList() {
         for (var i = 0; i < data.length; i++) {
           var thread = data[i];
           if (!thread) continue;
-          if (thread.fork === 'owner' || thread.fork === 'easy') continue;
+          if (thread.fork === 'easy') continue;
           var comments = Array.isArray(thread.comments) ? thread.comments : (Array.isArray(thread.chat) ? thread.chat : null);
           if (!comments) continue;
+          var isOwnerThread = thread.fork === 'owner';
           for (var j = 0; j < comments.length; j++) {
             var c = comments[j];
             if (!c) continue;
             var t = c.vposMs !== undefined ? Math.round(c.vposMs / 10) : (typeof c.vpos === 'number' ? Math.round(c.vpos) : NaN);
             var text = c.body !== undefined ? c.body : c.content;
             if (!isFinite(t) || !text) continue;
-            items.push({ t: t, text: text, blocked: danmakuBlocklistEnabled && isBlockedText(text), _fixed: isFixedCommentCommands(c.commands) || isFixedCommentMail(c.mail) });
+            // owner 弹幕进列表但不参与任何过滤: 不打屏蔽标记、不做展示层合并
+            items.push({ t: t, text: text, blocked: isOwnerThread ? false : (danmakuBlocklistEnabled && isBlockedText(text)), _fixed: isFixedCommentCommands(c.commands) || isFixedCommentMail(c.mail), _owner: isOwnerThread || undefined });
           }
         }
       }
@@ -1059,8 +1061,10 @@ function buildDanmakuBrowserList() {
     var visible = [];
     var blockedItems = [];
     var fixedItems = [];
+    var ownerItems = [];
     for (var di = 0; di < items.length; di++) {
       if (items[di].blocked) blockedItems.push(items[di]);
+      else if (items[di]._owner) ownerItems.push(items[di]); // owner 弹幕不参与展示层合并(原样逐条列出)
       else if (items[di]._fixed) fixedItems.push(items[di]); // 固定弹幕不做展示层合并(画面由引擎渐进合并)
       else visible.push(items[di]);
     }
@@ -1072,7 +1076,7 @@ function buildDanmakuBrowserList() {
     }
     // 被屏蔽弹幕展示层合并(保持 blocked 标记;时间窗相同)
     var blockedMerged = mergeDuplicateItems(blockedItems, danmakuDedupeWindow * 100);
-    items = blockedMerged.concat(fixedItems).concat(mergedOut);
+    items = blockedMerged.concat(ownerItems).concat(fixedItems).concat(mergedOut);
   }
   items.sort(function (a, b) { return a.t - b.t; });
   return items;

--- a/main.js
+++ b/main.js
@@ -30,7 +30,7 @@ var strokeColor = preferences.get("strokeColor") || '#000000';
 var strokeInversionColor = preferences.get("strokeInversionColor") || '#ffffff';
 var commentLimit = preferences.get("commentLimit") !== undefined ? preferences.get("commentLimit") : 0;
 var scrollSpeed = preferences.get("scrollSpeed") !== undefined ? preferences.get("scrollSpeed") : 1.0;
-var danmakuTimeOffsetSec = preferences.get("danmakuTimeOffset") !== undefined ? preferences.get("danmakuTimeOffset") : 0;
+var danmakuTimeOffsetSec = 0; // 弹幕偏移不做持久化: 偏移量因视频/弹幕文件而异,每个会话从 0 开始
 var danmakuFontFamily = preferences.get("danmakuFontFamily") || "";
 var danmakuFontWeight = preferences.get("danmakuFontWeight") || "400";
 var stylePreset = preferences.get("stylePreset") || "nico";
@@ -241,8 +241,6 @@ function applyDanmakuOffset(offsetSec) {
   var nextOffset = parseFloat(offsetSec);
   if (isNaN(nextOffset)) nextOffset = 0;
   danmakuTimeOffsetSec = nextOffset;
-  preferences.set("danmakuTimeOffset", danmakuTimeOffsetSec);
-  syncPreferencesSoon();
   if (overlayReady) {
     overlay.postMessage("set-danmaku-offset", { offset: danmakuTimeOffsetSec });
   }

--- a/main.js
+++ b/main.js
@@ -506,6 +506,7 @@ function applyDanmakuFilter(offset, limit) {
     danmakuFontFamily: danmakuFontFamily,
     danmakuFontWeight: danmakuFontWeight,
     preservePosition: true,
+    fixedCombo: danmakuDedupeEnabled,
   });
   sendDanmakuFilterInfo();
 }
@@ -697,6 +698,15 @@ function pickMergeColor(text) {
   return MERGE_COLORS[Math.floor(Math.random() * MERGE_COLORS.length)];
 }
 
+// 固定弹幕(ue/shita)识别: 预合并跳过固定弹幕,它们由渲染引擎做渐进合并(combo)
+function isFixedCommentCommands(cmds) {
+  return Array.isArray(cmds) && (cmds.indexOf('ue') !== -1 || cmds.indexOf('shita') !== -1);
+}
+function isFixedCommentMail(mail) {
+  if (typeof mail !== 'string') return false;
+  return /(^|\s)(ue|shita)(\s|$)/.test(mail);
+}
+
 // nico-json 去重: 每个 thread 的 comments 内合并(保留组内最早 comment 的全部字段)
 function dedupeNicoJson(encodedContent) {
   if (!(danmakuDedupeWindow > 0)) return encodedContent;
@@ -722,6 +732,11 @@ function dedupeNicoJson(encodedContent) {
       var t = c.vposMs !== undefined ? Math.round(c.vposMs / 10) : (typeof c.vpos === 'number' ? Math.round(c.vpos) : NaN);
       var text = c.body !== undefined ? c.body : c.content;
       if (!isFinite(t) || !text) { entries.push({ t: 0, text: '', _c: c, _skip: true }); continue; }
+      // 固定弹幕(ue/shita)跳过预合并: 由渲染引擎做渐进合并(x2→x3),预合并会抢走它的数据
+      if (isFixedCommentCommands(c.commands) || isFixedCommentMail(c.mail)) {
+        entries.push({ t: t, text: text, _c: c, _skip: true });
+        continue;
+      }
       entries.push({ t: t, text: text, _c: c });
     }
     var merged = mergeDuplicateItems(entries, windowMs);
@@ -769,6 +784,8 @@ function dedupeContent(encodedContent, ft) {
     for (var i = 0; i < list.length; i++) {
       var d = list[i];
       if (!d || typeof d.t !== 'number' || !isFinite(d.t) || !d.text) { entries.push({ t: 0, text: '', _d: d, _skip: true }); continue; }
+      // 固定弹幕(ue/shita)跳过预合并: 由渲染引擎做渐进合并
+      if (isFixedCommentCommands(d._commands)) { entries.push({ t: Math.round(d.t), text: d.text, _d: d, _skip: true }); continue; }
       entries.push({ t: Math.round(d.t), text: d.text, _d: d });
     }
     var merged = mergeDuplicateItems(entries, windowMs);
@@ -805,8 +822,12 @@ function dedupeContent(encodedContent, ft) {
     var t = m[1].indexOf('vpos="') !== -1
       ? parseInt((m[1].match(/vpos="(\d+)"/) || [0, 0])[1], 10) || 0
       : Math.round((parseFloat((m[1].match(/p="([^"]*)"/) || [0, '0'])[1].split(',')[0]) || 0) * 100);
+    // 固定弹幕(ue/shita / p mode 4・5)跳过预合并: 由渲染引擎做渐进合并
+    var isFixed = ft === 'nico-xml'
+      ? isFixedCommentMail((m[1].match(/mail="([^"]*)"/) || [0, ''])[1])
+      : [4, 5].indexOf(parseInt((m[1].match(/p="([^"]*)"/) || [0, '0'])[1].split(',')[1], 10)) !== -1;
     // start = 本行在原始串中的位置: 重建时按序推进,无需重扫/线性查找(O(n))
-    lines.push({ t: t, text: decodeXmlText(m[2]), head: m[1], tail: m[3], full: m[0], start: m.index });
+    lines.push({ t: t, text: decodeXmlText(m[2]), head: m[1], tail: m[3], full: m[0], start: m.index, _skip: isFixed || undefined });
   }
   if (lines.length === 0) return encodedContent;
   var merged = mergeDuplicateItems(lines, windowMs);
@@ -991,7 +1012,7 @@ function buildDanmakuBrowserList() {
             var t = c.vposMs !== undefined ? Math.round(c.vposMs / 10) : (typeof c.vpos === 'number' ? Math.round(c.vpos) : NaN);
             var text = c.body !== undefined ? c.body : c.content;
             if (!isFinite(t) || !text) continue;
-            items.push({ t: t, text: text, blocked: danmakuBlocklistEnabled && isBlockedText(text) });
+            items.push({ t: t, text: text, blocked: danmakuBlocklistEnabled && isBlockedText(text), _fixed: isFixedCommentCommands(c.commands) || isFixedCommentMail(c.mail) });
           }
         }
       }
@@ -1002,7 +1023,7 @@ function buildDanmakuBrowserList() {
           var d = list[k];
           if (!d || typeof d.t !== 'number' || !isFinite(d.t) || !d.text) continue;
           var st = simplifyText(d.text);
-          items.push({ t: Math.round(d.t), text: st, blocked: danmakuBlocklistEnabled && isBlockedText(st) });
+          items.push({ t: Math.round(d.t), text: st, blocked: danmakuBlocklistEnabled && isBlockedText(st), _fixed: isFixedCommentCommands(d._commands) });
         }
       }
     } else {
@@ -1012,7 +1033,7 @@ function buildDanmakuBrowserList() {
         while ((m = reChat.exec(rawStr)) !== null) {
           if (!m[2]) continue;
           var ct = simplifyText(decodeXmlText(m[2]));
-          items.push({ t: parseInt(m[1], 10) || 0, text: ct, blocked: danmakuBlocklistEnabled && isBlockedText(ct) });
+          items.push({ t: parseInt(m[1], 10) || 0, text: ct, blocked: danmakuBlocklistEnabled && isBlockedText(ct), _fixed: isFixedCommentMail((m[0].match(/mail="([^"]*)"/) || [0, ''])[1]) });
         }
       } else {
         var reD = /<d\s+p="([^"]*)"[^>]*>([\s\S]*?)<\/d>/g;
@@ -1022,7 +1043,7 @@ function buildDanmakuBrowserList() {
           var sec = parseFloat(parts[0]);
           if (!isFinite(sec) || !m2[2]) continue;
           var bt = simplifyText(decodeXmlText(m2[2]));
-          items.push({ t: Math.round(sec * 100), text: bt, blocked: danmakuBlocklistEnabled && isBlockedText(bt) });
+          items.push({ t: Math.round(sec * 100), text: bt, blocked: danmakuBlocklistEnabled && isBlockedText(bt), _fixed: [4, 5].indexOf(parseInt(parts[1], 10)) !== -1 });
         }
       }
     }
@@ -1037,8 +1058,10 @@ function buildDanmakuBrowserList() {
   if (danmakuDedupeEnabled && danmakuDedupeWindow > 0) {
     var visible = [];
     var blockedItems = [];
+    var fixedItems = [];
     for (var di = 0; di < items.length; di++) {
       if (items[di].blocked) blockedItems.push(items[di]);
+      else if (items[di]._fixed) fixedItems.push(items[di]); // 固定弹幕不做展示层合并(画面由引擎渐进合并)
       else visible.push(items[di]);
     }
     var mergedOut = mergeDuplicateItems(visible, danmakuDedupeWindow * 100);
@@ -1049,7 +1072,7 @@ function buildDanmakuBrowserList() {
     }
     // 被屏蔽弹幕展示层合并(保持 blocked 标记;时间窗相同)
     var blockedMerged = mergeDuplicateItems(blockedItems, danmakuDedupeWindow * 100);
-    items = blockedMerged.concat(mergedOut);
+    items = blockedMerged.concat(fixedItems).concat(mergedOut);
   }
   items.sort(function (a, b) { return a.t - b.t; });
   return items;
@@ -1116,7 +1139,8 @@ function resendDanmakuToOverlay() {
     danmakuTimeOffsetSec: danmakuTimeOffsetSec,
     danmakuFontFamily: danmakuFontFamily,
     danmakuFontWeight: danmakuFontWeight,
-    preservePosition: true
+    preservePosition: true,
+    fixedCombo: danmakuDedupeEnabled
   });
 }
 
@@ -1619,6 +1643,7 @@ function ddpAddToFileListAndLoad(episodeId, animeTitle, episodeTitle, converted,
       commentLimit: commentLimit,
       scrollSpeed: scrollSpeed,
       preservePosition: true,
+      fixedCombo: danmakuDedupeEnabled,
     };
     if (overlayReady) {
       overlay.postMessage("load-danmaku", payload);
@@ -1841,6 +1866,7 @@ function loadLocalDanmaku(fileInfo) {
     commentLimit: commentLimit,
     scrollSpeed: scrollSpeed,
     preservePosition: true,
+    fixedCombo: danmakuDedupeEnabled,
   };
 
   if (overlayReady) {
@@ -1872,7 +1898,8 @@ function markOverlayReady() {
     danmakuTimeOffsetSec: danmakuTimeOffsetSec,
     danmakuFontFamily: danmakuFontFamily,
     danmakuFontWeight: danmakuFontWeight,
-    danmakuForceSimplified: danmakuForceSimplified
+    danmakuForceSimplified: danmakuForceSimplified,
+    fixedCombo: danmakuDedupeEnabled
   });
 
   if (pendingDanmaku) {
@@ -1973,6 +2000,7 @@ function loadManualDanmakuFile(path) {
     commentLimit: commentLimit,
     scrollSpeed: scrollSpeed,
     preservePosition: true,
+    fixedCombo: danmakuDedupeEnabled,
   };
 
   if (overlayReady) {
@@ -2305,6 +2333,7 @@ function registerSidebarHandlers() {
       commentLimit: commentLimit,
       scrollSpeed: scrollSpeed,
       preservePosition: true,
+      fixedCombo: danmakuDedupeEnabled,
     };
 
     overlay.postMessage("load-danmaku", selectPayload);

--- a/main.js
+++ b/main.js
@@ -2493,6 +2493,8 @@ event.on("iina.plugin-overlay-loaded", function () {
 
 event.on("iina.file-loaded", function (url) {
   currentVideoUrl = url;
+  // 偏移量因视频/弹幕文件而异(且不持久化),切换视频时归零并同步 overlay/sidebar
+  applyDanmakuOffset(0);
   if (danmakuEnabled) loadDanmakuForVideo(url);
 });
 

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -9,8 +9,8 @@
   <canvas id="niconicomments-canvas"></canvas>
   <!-- ?v= 版本参数: WKWebView 会按 URL 缓存 file:// 脚本子资源,不加参数会导致
        插件重载后 overlay 仍运行旧 JS(曾导致过滤 tab 收不到任何数据) -->
-  <script src="lib/niconicomments.min.js?v=8"></script>
-  <script src="input.js?v=8"></script>
-  <script src="main.js?v=8"></script>
+  <script src="lib/niconicomments.min.js?v=9"></script>
+  <script src="input.js?v=9"></script>
+  <script src="main.js?v=9"></script>
 </body>
 </html>

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -9,8 +9,8 @@
   <canvas id="niconicomments-canvas"></canvas>
   <!-- ?v= 版本参数: WKWebView 会按 URL 缓存 file:// 脚本子资源,不加参数会导致
        插件重载后 overlay 仍运行旧 JS(曾导致过滤 tab 收不到任何数据) -->
-  <script src="lib/niconicomments.min.js?v=9"></script>
-  <script src="input.js?v=9"></script>
-  <script src="main.js?v=9"></script>
+  <script src="lib/niconicomments.min.js?v=10"></script>
+  <script src="input.js?v=10"></script>
+  <script src="main.js?v=10"></script>
 </body>
 </html>

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -9,8 +9,8 @@
   <canvas id="niconicomments-canvas"></canvas>
   <!-- ?v= 版本参数: WKWebView 会按 URL 缓存 file:// 脚本子资源,不加参数会导致
        插件重载后 overlay 仍运行旧 JS(曾导致过滤 tab 收不到任何数据) -->
-  <script src="lib/niconicomments.min.js?v=7"></script>
-  <script src="input.js?v=7"></script>
-  <script src="main.js?v=7"></script>
+  <script src="lib/niconicomments.min.js?v=8"></script>
+  <script src="input.js?v=8"></script>
+  <script src="main.js?v=8"></script>
 </body>
 </html>

--- a/overlay/lib/niconicomments.min.js
+++ b/overlay/lib/niconicomments.min.js
@@ -2844,10 +2844,9 @@ Released under the MIT License.
 		return typeof base === "string" && base.length > 0 && !base.includes("\n");
 	};
 	/**
-	* 应用一条链的变更:宿主延长显示计时并预留占位宽度,其余成员隐藏。
-	* 占位宽度 = 最大文本(原文x最大计数)的实测宽度:固定弹幕居中显示,
-	* 预留宽度后宿主以占位盒整体居中、文本左对齐锚定,xN 增长时位置不移动。
-	* 测量失败(异常 comment 实现)时返回 null,该链全员保持原样。
+	* 应用一条链的变更:宿主延长显示计时,其余成员隐藏。
+	* xN 增长时文本变长,固定弹幕按常规规则自然重新居中(轻微移动),不做占位预留。
+	* 宿主/末成员缺失(异常数据)时返回 null,该链全员保持原样。
 	*/
 	const makeChain = (members) => {
 		const host = members[0];
@@ -2862,20 +2861,7 @@ Released under the MIT License.
 		const lineHeight = host.comment.lineHeight;
 		const fontSize = host.comment.fontSize;
 		const height = host.comment.height;
-		let reservedWidth;
-		try {
-			host.content = `${base}x${members.length}`;
-			reservedWidth = Math.max(host.comment.width, host.width);
-			host.comment.charSize = charSize;
-			host.comment.lineHeight = lineHeight;
-			host.comment.fontSize = fontSize;
-			host.content = base;
-		} catch (_e) {
-			return null;
-		}
 		host.comment.long = end - host.vpos;
-		host.comment.width = reservedWidth;
-		host.fixedComboReservedWidth = reservedWidth;
 		for (let i = 1; i < members.length; i++) {
 			const member = members[i];
 			if (member) member.comment.invisible = true;
@@ -7908,10 +7894,6 @@ void main() {
 			if (comment.loc === "shita") posY = this.config.canvasHeight - comment.posY - comment.height;
 			else posY = comment.posY;
 			element.textContent = comment.content;
-			if (comment.fixedComboReservedWidth !== void 0) {
-				element.style.width = `calc(${comment.fixedComboReservedWidth} * var(--dm-unit))`;
-				element.style.textAlign = "left";
-			}
 			const lineWidth = getConfig(this.config.contextLineWidth, comment.flash);
 			const strokeColor = getStrokeColor(c, this.config);
 			const strokeWidthPx = lineWidth * drawScale * fontScale * layerScale;
@@ -8501,12 +8483,10 @@ void main() {
 				changed = true;
 				const host = chain.host;
 				try {
-					var _host$fixedComboReser;
 					host.comment.charSize = chain.charSize;
 					host.comment.lineHeight = chain.lineHeight;
 					host.comment.fontSize = chain.fontSize;
 					host.content = count > 1 ? `${chain.base}x${count}` : chain.base;
-					host.comment.width = (_host$fixedComboReser = host.fixedComboReservedWidth) !== null && _host$fixedComboReser !== void 0 ? _host$fixedComboReser : host.comment.width;
 					host.comment.height = chain.height;
 					host.comment.color = count > 1 ? chain.color : chain.originalColor;
 				} catch (e) {

--- a/overlay/lib/niconicomments.min.js
+++ b/overlay/lib/niconicomments.min.js
@@ -1465,6 +1465,7 @@ Released under the MIT License.
 			flashScriptCharOffset: (i) => isFiniteNumberInRange(i, { max: MAX_CONFIG_RATIO }),
 			flashScriptChar: isValidFlashScriptChar,
 			flashThreshold: (i) => isFiniteNumberInRange(i, { max: MAX_UNIX_TIME_SECONDS }),
+			fixedCombo: (i) => typeof i === "boolean",
 			fontSize: isBoundedFontSizeConfig,
 			fpsInterval: (i) => isFiniteNumberInRange(i, { max: MAX_COMMENT_RANGE }),
 			hideCommentOrder: isHideCommentOrder,
@@ -2813,6 +2814,149 @@ Released under the MIT License.
 	const getTimeBucket = (time, bucketSize) => bucketSize === Infinity ? 0 : Math.floor(time / bucketSize);
 	const isSameCommentArtTime = (time, timeObj, config) => timeObj.range.start - config.sameCATimestampRange <= time && timeObj.range.end + config.sameCATimestampRange >= time;
 	//#endregion
+	//#region src/utils/fixedCombo.ts
+	/** 合并后的颜色池(鲜艳色,与插件侧预合并色池一致) */
+	const COMBO_COLORS = [
+		"#FF0000",
+		"#FF8080",
+		"#FFCC00",
+		"#FFFF00",
+		"#00FF00",
+		"#00FFFF",
+		"#0000FF",
+		"#800080"
+	];
+	/** 链的最大时长上限(与单条弹幕 MAX_COMMENT_LONG 一致,防止刷屏链无限延长 timeline) */
+	const MAX_CHAIN_LONG = 12e3;
+	const hashText = (text) => {
+		let h = 0;
+		for (let i = 0; i < text.length; i++) h = h * 31 + text.charCodeAt(i) | 0;
+		return Math.abs(h);
+	};
+	const pickFixedComboColor = (text) => {
+		var _COMBO_COLORS;
+		return (_COMBO_COLORS = COMBO_COLORS[hashText(text) % COMBO_COLORS.length]) !== null && _COMBO_COLORS !== void 0 ? _COMBO_COLORS : "#FFCC00";
+	};
+	const isComboCandidate = (comment) => {
+		if (!comment || comment.invisible || comment.owner) return false;
+		if (comment.loc === "naka") return false;
+		const base = comment.content;
+		return typeof base === "string" && base.length > 0 && !base.includes("\n");
+	};
+	/**
+	* 应用一条链的变更:宿主延长显示计时并预留占位宽度,其余成员隐藏。
+	* 占位宽度 = 最大文本(原文x最大计数)的实测宽度:固定弹幕居中显示,
+	* 预留宽度后宿主以占位盒整体居中、文本左对齐锚定,xN 增长时位置不移动。
+	* 测量失败(异常 comment 实现)时返回 null,该链全员保持原样。
+	*/
+	const makeChain = (members) => {
+		const host = members[0];
+		if (!host) return null;
+		const base = host.content;
+		const originalColor = host.comment.color;
+		const color = pickFixedComboColor(base);
+		const last = members[members.length - 1];
+		if (!last) return null;
+		const end = last.vpos + last.long;
+		const charSize = host.comment.charSize;
+		const lineHeight = host.comment.lineHeight;
+		const fontSize = host.comment.fontSize;
+		const height = host.comment.height;
+		let reservedWidth;
+		try {
+			host.content = `${base}x${members.length}`;
+			reservedWidth = Math.max(host.comment.width, host.width);
+			host.comment.charSize = charSize;
+			host.comment.lineHeight = lineHeight;
+			host.comment.fontSize = fontSize;
+			host.content = base;
+		} catch (_e) {
+			return null;
+		}
+		host.comment.long = end - host.vpos;
+		host.comment.width = reservedWidth;
+		host.fixedComboReservedWidth = reservedWidth;
+		for (let i = 1; i < members.length; i++) {
+			const member = members[i];
+			if (member) member.comment.invisible = true;
+		}
+		return {
+			host,
+			base,
+			originalColor,
+			color,
+			memberVposes: members.map((m) => m.vpos).sort((a, b) => a - b),
+			end,
+			charSize,
+			lineHeight,
+			fontSize,
+			height,
+			currentCount: 0
+		};
+	};
+	/**
+	* 预计算全部合并链。在 createCommentInstance 之后、getCommentPos 之前调用。
+	* @param comments 全部评论实例
+	* @returns 合并链列表(仅含成员 ≥ 2 的链)
+	*/
+	const buildFixedComboChains = (comments) => {
+		const groups = /* @__PURE__ */ new Map();
+		for (const comment of comments) {
+			if (!isComboCandidate(comment)) continue;
+			const key = `${comment.loc}\u0000${comment.comment.size}\u0000${comment.content}`;
+			const list = groups.get(key);
+			if (list) list.push(comment);
+			else groups.set(key, [comment]);
+		}
+		const chains = [];
+		for (const [, list] of groups) {
+			if (list.length < 2) continue;
+			list.sort((a, b) => a.vpos - b.vpos || a.index - b.index);
+			let chain = [];
+			let chainStart = 0;
+			let curEnd = Number.NEGATIVE_INFINITY;
+			const flush = () => {
+				if (chain.length >= 2) {
+					const built = makeChain(chain);
+					if (built) chains.push(built);
+				}
+				chain = [];
+			};
+			for (const comment of list) {
+				const ownEnd = comment.vpos + comment.long;
+				if (chain.length > 0 && comment.vpos < curEnd && ownEnd - chainStart <= MAX_CHAIN_LONG) {
+					chain.push(comment);
+					curEnd = ownEnd;
+				} else {
+					flush();
+					chain = [comment];
+					chainStart = comment.vpos;
+					curEnd = ownEnd;
+				}
+			}
+			flush();
+		}
+		return chains;
+	};
+	/**
+	* 计算指定 vpos 时链的渐进计数(纯函数,seek 安全)。
+	* @param chain 合并链
+	* @param vpos 当前 vpos
+	* @returns 在屏成员数(0 = 链未在屏)
+	*/
+	const fixedComboCountAt = (chain, vpos) => {
+		if (vpos < chain.host.vpos || vpos >= chain.end) return 0;
+		let lo = 0;
+		let hi = chain.memberVposes.length;
+		while (lo < hi) {
+			var _chain$memberVposes$m;
+			const mid = lo + hi >> 1;
+			if (((_chain$memberVposes$m = chain.memberVposes[mid]) !== null && _chain$memberVposes$m !== void 0 ? _chain$memberVposes$m : Number.POSITIVE_INFINITY) <= vpos) lo = mid + 1;
+			else hi = mid;
+		}
+		return lo;
+	};
+	//#endregion
 	//#region src/utils/sort.ts
 	/**
 	* 特定のキーを使ってオブジェクトをソートする
@@ -3376,8 +3520,10 @@ Released under the MIT License.
 		arrayEqual: () => arrayEqual,
 		arrayPush: () => arrayPush,
 		buildAtButtonComment: () => buildAtButtonComment,
+		buildFixedComboChains: () => buildFixedComboChains,
 		changeCALayer: () => changeCALayer,
 		clampFlashContent: () => clampFlashContent,
+		fixedComboCountAt: () => fixedComboCountAt,
 		getButtonParts: () => getButtonParts,
 		getCharSize: () => getCharSize,
 		getConfig: () => getConfig,
@@ -3403,6 +3549,7 @@ Released under the MIT License.
 		parseCommandAndNicoScript: () => parseCommandAndNicoScript,
 		parseContent: () => parseContent,
 		parseFont: () => parseFont,
+		pickFixedComboColor: () => pickFixedComboColor,
 		processFixedComment: () => processFixedComment,
 		processMovableComment: () => processMovableComment
 	});
@@ -5426,6 +5573,11 @@ Released under the MIT License.
 			* desc: 古い方から上限まで
 			*/
 			hideCommentOrder: "asc",
+			/**
+			* 固定コメント(ue/shita)の段階的マージ(combo)
+			* 同一テキストの固定コメントが先行コメント表示中に到達すると x2, x3… と段階的に更新される
+			*/
+			fixedCombo: false,
 			/**
 			* 改行リサイズの行数
 			*/
@@ -7587,6 +7739,10 @@ void main() {
   from { transform: translateX(calc(var(--dm-from) * var(--dm-unit))); }
   to   { transform: translateX(calc(var(--dm-to) * var(--dm-unit))); }
 }
+@keyframes dm-pop {
+  from { transform: translateX(-50%) scale(1.15); }
+  to   { transform: translateX(-50%) scale(1); }
+}
 [data-dm-css-container] {
   position: fixed;
   top: 0;
@@ -7686,7 +7842,8 @@ void main() {
 			}
 			const newElements = [];
 			for (let i = startIndex; i < endIndex; i++) {
-				const isReverse = comments[i].owner ? frameActiveState.reverseActiveOwner : frameActiveState.reverseActiveViewer;
+				var _comments$i;
+				const isReverse = ((_comments$i = comments[i]) === null || _comments$i === void 0 ? void 0 : _comments$i.owner) ? frameActiveState.reverseActiveOwner : frameActiveState.reverseActiveViewer;
 				const comment = comments[i];
 				if (!comment || comment.invisible) continue;
 				this.activeSeenGeneration.set(comment.index, generation);
@@ -7699,7 +7856,10 @@ void main() {
 					const newEl = this.activeElements.get(comment.index);
 					if (newEl) newElements.push(newEl);
 				} else if (comment.loc === "naka" && (isSeek || isReverse !== this.activeElementReverse.get(comment.index))) this.reanimateScroll(comment, vpos, isReverse);
-				else if (isSeek) this.setupFixedAnimation(element);
+				else {
+					if (comment.loc !== "naka") this.syncFixedCombo(element, comment);
+					if (isSeek) this.setupFixedAnimation(element);
+				}
 				drawnCount++;
 			}
 			this.lastUpdateVpos = vpos;
@@ -7713,8 +7873,10 @@ void main() {
 					const anims = element.getAnimations();
 					let stillPlaying = false;
 					for (let i = 0, n = anims.length; i < n; i++) {
-						var _anims$i;
-						const state = (_anims$i = anims[i]) === null || _anims$i === void 0 ? void 0 : _anims$i.playState;
+						const anim = anims[i];
+						if (!anim) continue;
+						if (anim.animationName === "dm-pop") continue;
+						const state = anim.playState;
 						if (state === "running" || state === "paused") {
 							stillPlaying = true;
 							break;
@@ -7746,6 +7908,10 @@ void main() {
 			if (comment.loc === "shita") posY = this.config.canvasHeight - comment.posY - comment.height;
 			else posY = comment.posY;
 			element.textContent = comment.content;
+			if (comment.fixedComboReservedWidth !== void 0) {
+				element.style.width = `calc(${comment.fixedComboReservedWidth} * var(--dm-unit))`;
+				element.style.textAlign = "left";
+			}
 			const lineWidth = getConfig(this.config.contextLineWidth, comment.flash);
 			const strokeColor = getStrokeColor(c, this.config);
 			const strokeWidthPx = lineWidth * drawScale * fontScale * layerScale;
@@ -7801,7 +7967,7 @@ void main() {
 			for (const [index, element] of this.activeElements) {
 				var _this$activeElementRe;
 				const comment = element.__dmComment;
-				if (!comment || comment.loc !== "naka") continue;
+				if ((comment === null || comment === void 0 ? void 0 : comment.loc) !== "naka") continue;
 				const isReverse = (_this$activeElementRe = this.activeElementReverse.get(index)) !== null && _this$activeElementRe !== void 0 ? _this$activeElementRe : false;
 				this.reanimateScroll(comment, this.lastUpdateVpos, isReverse);
 			}
@@ -7836,6 +8002,22 @@ void main() {
 		setupFixedAnimation(element) {
 			element.style.left = "50%";
 			element.style.transform = "translateX(-50%)";
+		}
+		/**
+		* fixedCombo 宿主の段階更新を DOM に反映する。
+		* エンジン側(_updateFixedCombo)が comment.content / comment.color を更新済みなので、
+		* ここでテキストと色を同期し、テキスト変化時に pop アニメーションを再生する。
+		* 要素は固定幅の予約ボックス(中央揃え・テキスト左詰め)のため位置は動かない。
+		*/
+		syncFixedCombo(element, comment) {
+			const c = comment.comment;
+			if (element.textContent !== comment.content) {
+				element.textContent = comment.content;
+				element.style.color = c.color;
+				element.style.animation = "";
+				element.offsetWidth;
+				element.style.animation = "dm-pop 0.25s ease-out";
+			}
 		}
 		getEffectiveAlpha(c) {
 			if (typeof c.opacity === "number") return c.opacity;
@@ -8029,6 +8211,7 @@ void main() {
 			_defineProperty(this, "commentArrayIndexMap", void 0);
 			_defineProperty(this, "processedCommentIndex", void 0);
 			_defineProperty(this, "comments", void 0);
+			_defineProperty(this, "fixedComboChains", []);
 			_defineProperty(this, "destroyed", false);
 			_defineProperty(this, "renderer", void 0);
 			_defineProperty(this, "cssRenderer", null);
@@ -8107,6 +8290,7 @@ void main() {
 				console.error("Failed to destroy comment", e);
 			}
 			this.comments = [];
+			this.fixedComboChains = [];
 			this.commentArrayIndexMap = /* @__PURE__ */ new WeakMap();
 			this._clearTimeline();
 			this._clearCollision();
@@ -8189,6 +8373,7 @@ void main() {
 			}
 			this.plugins = plugins;
 			this.lazyCommentOrderSortedByVpos = areCommentsSortedByVpos(instances);
+			if (this.ctx.config.fixedCombo) this.fixedComboChains = buildFixedComboChains(instances);
 			if (!this.ctx.options.lazy || !this.lazyCommentOrderSortedByVpos) {
 				this.getCommentPos(instances, instances.length);
 				this.sortTimelineComment();
@@ -8301,6 +8486,36 @@ void main() {
 			this._cachedSplit = null;
 		}
 		/**
+		* 固定弹幕 combo 渐进更新:按 vpos 重算各链计数,计数变化时更新宿主文本/颜色。
+		* 纯函数式(从静态的链定义重算),seek 后自动正确。
+		* @param vpos 当前 vpos
+		* @returns 是否有链计数变化(需要重绘)
+		*/
+		_updateFixedCombo(vpos) {
+			if (this.fixedComboChains.length === 0) return false;
+			let changed = false;
+			for (const chain of this.fixedComboChains) {
+				const count = fixedComboCountAt(chain, vpos);
+				if (count === chain.currentCount) continue;
+				chain.currentCount = count;
+				changed = true;
+				const host = chain.host;
+				try {
+					var _host$fixedComboReser;
+					host.comment.charSize = chain.charSize;
+					host.comment.lineHeight = chain.lineHeight;
+					host.comment.fontSize = chain.fontSize;
+					host.content = count > 1 ? `${chain.base}x${count}` : chain.base;
+					host.comment.width = (_host$fixedComboReser = host.fixedComboReservedWidth) !== null && _host$fixedComboReser !== void 0 ? _host$fixedComboReser : host.comment.width;
+					host.comment.height = chain.height;
+					host.comment.color = count > 1 ? chain.color : chain.originalColor;
+				} catch (e) {
+					this._log(`_updateFixedCombo: failed to update host index=${host.index}: ${e instanceof Error ? e.message : String(e)}`);
+				}
+			}
+			return changed;
+		}
+		/**
 		* キャンバスを描画する
 		* @param vpos 動画の現在位置の100倍 ニコニコから吐き出されるコメントの位置情報は主にこれ
 		* @param forceRendering キャッシュを使用せずに再描画を強制するか
@@ -8343,13 +8558,14 @@ void main() {
 			this.resolveLazyCommentWindow(vposInt, frameBanActive ? BAN_FRAME_POSITION_RESOLUTION_BUDGET : void 0);
 			const timelineRange = (_this$timeline$vposIn = this.timeline[vposInt]) !== null && _this$timeline$vposIn !== void 0 ? _this$timeline$vposIn : EMPTY_TIMELINE;
 			const lastTimelineRange = (_this$timeline$this$l = this.timeline[this.lastVposInt]) !== null && _this$timeline$this$l !== void 0 ? _this$timeline$this$l : EMPTY_TIMELINE;
+			const fixedComboChanged = this._updateFixedCombo(vpos);
 			const currentHasNaka = hasNakaComment(timelineRange);
 			const lastHasNaka = ((_this$_cachedSplit = this._cachedSplit) === null || _this$_cachedSplit === void 0 ? void 0 : _this$_cachedSplit.vpos) === this.lastVposInt ? this._cachedSplit.hasNaka : hasNakaComment(lastTimelineRange);
 			this._cachedSplit = {
 				vpos: vposInt,
 				hasNaka: currentHasNaka
 			};
-			if (!forceRendering && !requiresDynamicFrameRedraw && !currentHasNaka && !lastHasNaka && frameBanActive === this.lastFrameBanActive) {
+			if (!forceRendering && !requiresDynamicFrameRedraw && !fixedComboChanged && !currentHasNaka && !lastHasNaka && frameBanActive === this.lastFrameBanActive) {
 				if (arrayEqual(timelineRange, lastTimelineRange)) return false;
 			}
 			this.frameDirty = true;

--- a/overlay/lib/niconicomments.min.js
+++ b/overlay/lib/niconicomments.min.js
@@ -2871,7 +2871,8 @@ Released under the MIT License.
 			base,
 			originalColor,
 			color,
-			memberVposes: members.map((m) => m.vpos).sort((a, b) => a - b),
+			memberVposes: members.map((m) => m.vpos),
+			memberIndices: members.map((m) => m.index),
 			end,
 			charSize,
 			lineHeight,
@@ -7878,7 +7879,7 @@ void main() {
 			return drawnCount;
 		}
 		createCommentElement(comment, vpos, isReverse) {
-			var _ref, _this$config$fonts$ht;
+			var _ref, _this$config$fonts$ht, _comment$fixedComboZI;
 			const element = this.getElementFromPool();
 			const c = comment.comment;
 			const drawScale = getConfig(this.config.commentScale, comment.flash);
@@ -7908,7 +7909,7 @@ void main() {
 			element.style.fontSize = `calc(${fontSizePx} * var(--dm-unit))`;
 			element.style.lineHeight = String(c.lineHeight / (renderFontSize * fontScale));
 			element.style.color = c.color;
-			element.style.zIndex = String((comment.owner ? 1073741824 : 0) + comment.index + 1);
+			element.style.zIndex = String((comment.owner ? 1073741824 : 0) + ((_comment$fixedComboZI = comment.fixedComboZIndex) !== null && _comment$fixedComboZI !== void 0 ? _comment$fixedComboZI : comment.index) + 1);
 			element.style.webkitTextStroke = `calc(${strokeWidthPx} * var(--dm-unit)) ${strokeColor}`;
 			if (strokeWidthPx > 0) element.style.textShadow = `0 0 2px ${strokeColor}`;
 			if (effectiveAlpha !== 1) element.style.opacity = String(effectiveAlpha);
@@ -7994,8 +7995,10 @@ void main() {
 		syncFixedCombo(element, comment) {
 			const c = comment.comment;
 			if (element.textContent !== comment.content) {
+				var _comment$fixedComboZI2;
 				element.textContent = comment.content;
 				element.style.color = c.color;
+				element.style.zIndex = String((comment.owner ? 1073741824 : 0) + ((_comment$fixedComboZI2 = comment.fixedComboZIndex) !== null && _comment$fixedComboZI2 !== void 0 ? _comment$fixedComboZI2 : comment.index) + 1);
 				element.style.animation = "";
 				element.offsetWidth;
 				element.style.animation = "dm-pop 0.25s ease-out";
@@ -8113,7 +8116,10 @@ void main() {
 	var _NiconiComments;
 	const EMPTY_TIMELINE = Object.freeze([]);
 	const BAN_FRAME_POSITION_RESOLUTION_BUDGET = 256;
-	const TIMELINE_COMMENT_SORT = (a, b) => Number(a.owner) - Number(b.owner) || a.index - b.index;
+	const TIMELINE_COMMENT_SORT = (a, b) => {
+		var _a$fixedComboZIndex, _b$fixedComboZIndex;
+		return Number(a.owner) - Number(b.owner) || ((_a$fixedComboZIndex = a.fixedComboZIndex) !== null && _a$fixedComboZIndex !== void 0 ? _a$fixedComboZIndex : a.index) - ((_b$fixedComboZIndex = b.fixedComboZIndex) !== null && _b$fixedComboZIndex !== void 0 ? _b$fixedComboZIndex : b.index);
+	};
 	const isFiniteVpos = (vpos) => Number.isFinite(vpos);
 	const isFinitePosition = (pos) => Number.isFinite(pos.x) && Number.isFinite(pos.y);
 	const rejectInvalidCommentPosition = (comment) => {
@@ -8483,17 +8489,31 @@ void main() {
 				changed = true;
 				const host = chain.host;
 				try {
+					var _chain$memberIndices;
 					host.comment.charSize = chain.charSize;
 					host.comment.lineHeight = chain.lineHeight;
 					host.comment.fontSize = chain.fontSize;
 					host.content = count > 1 ? `${chain.base}x${count}` : chain.base;
 					host.comment.height = chain.height;
 					host.comment.color = count > 1 ? chain.color : chain.originalColor;
+					host.fixedComboZIndex = (_chain$memberIndices = chain.memberIndices[count - 1]) !== null && _chain$memberIndices !== void 0 ? _chain$memberIndices : host.index;
 				} catch (e) {
 					this._log(`_updateFixedCombo: failed to update host index=${host.index}: ${e instanceof Error ? e.message : String(e)}`);
 				}
+				this._resortFixedComboChainTimeline(chain);
 			}
 			return changed;
+		}
+		/**
+		* combo 计数变化后重排链覆盖的 timeline 槽位。
+		* 排序比较器使用 fixedComboZIndex,宿主的新 z 序由此生效。
+		* @param chain 合并链
+		*/
+		_resortFixedComboChainTimeline(chain) {
+			for (let v = chain.host.vpos; v < chain.end; v++) {
+				const item = this.timeline[v];
+				if (item) item.sort(TIMELINE_COMMENT_SORT);
+			}
 		}
 		/**
 		* キャンバスを描画する

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -14,6 +14,7 @@ let scrollSpeed = 1.0; // 滚动速度倍率 (0.5 ~ 2.0), 通过 naka 弹幕 lon
 let danmakuTimeOffsetSec = 0;
 let danmakuFontFamily = "";
 let danmakuFontWeight = "";
+let fixedComboEnabled = false; // 固定弹幕渐进合并(= main 的去重开关)
 
 let niconiComments = null;
 let nicoRawData = null;
@@ -245,6 +246,7 @@ function initCanvasRenderer(data) {
       contextLineWidth: { html5: strokeWidth, flash: strokeWidth },
       commentLimit: commentLimit > 0 ? commentLimit : undefined,
       fonts: buildDanmakuFontConfig(),
+      fixedCombo: fixedComboEnabled,
     },
   });
   nicoRawData = data;
@@ -331,6 +333,7 @@ iina.onMessage("load-danmaku", (data) => {
   if (data.danmakuTimeOffsetSec !== undefined) danmakuTimeOffsetSec = Number(data.danmakuTimeOffsetSec) || 0;
   if (data.danmakuFontFamily !== undefined) danmakuFontFamily = data.danmakuFontFamily || "";
   if (data.danmakuFontWeight !== undefined) danmakuFontWeight = data.danmakuFontWeight || "";
+  if (data.fixedCombo !== undefined) fixedComboEnabled = !!data.fixedCombo;
   if (data.opacity !== undefined) {
     canvasOpacity = data.opacity;
     const canvas = document.getElementById('niconicomments-canvas');
@@ -532,6 +535,7 @@ iina.onMessage("apply-settings", (data) => {
   if (data.danmakuTimeOffsetSec !== undefined) danmakuTimeOffsetSec = Number(data.danmakuTimeOffsetSec) || 0;
   if (data.danmakuFontFamily !== undefined) danmakuFontFamily = data.danmakuFontFamily || "";
   if (data.danmakuFontWeight !== undefined) danmakuFontWeight = data.danmakuFontWeight || "";
+  if (data.fixedCombo !== undefined) fixedComboEnabled = !!data.fixedCombo;
 });
 
 // overlay 自身的 file:// 根目录(插件启动即加载,上报给 main 用于读 opencc.min.js

--- a/sidebar/index.css
+++ b/sidebar/index.css
@@ -823,6 +823,13 @@ kbd {
   text-decoration: line-through;
   text-decoration-color: var(--secondary-label);
 }
+/* owner(投稿者)弹幕: 不参与过滤,半透明浅红底色以示区分 */
+.danmaku-browser-row.owner {
+  background: rgba(255, 90, 90, 0.16);
+}
+.danmaku-browser-row.owner:hover {
+  background: rgba(255, 90, 90, 0.26);
+}
 .danmaku-browser-time {
   flex-shrink: 0;
   min-width: 40px;

--- a/sidebar/index.html
+++ b/sidebar/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="index.css?v=48" />
+  <link rel="stylesheet" href="index.css?v=49" />
   <title>Danmaku Control</title>
 </head>
 
@@ -346,7 +346,7 @@
     </div>
 
   </div>
-  <script src="index.js?v=47"></script>
+  <script src="index.js?v=48"></script>
 </body>
 
 </html>

--- a/sidebar/index.js
+++ b/sidebar/index.js
@@ -1332,7 +1332,7 @@ function browserRenderList(list) {
     if (node) continue;
     var item = items[row];
     var div = document.createElement("div");
-    div.className = "danmaku-browser-row" + (item.blocked ? " blocked" : "");
+    div.className = "danmaku-browser-row" + (item.blocked ? " blocked" : "") + (item.owner ? " owner" : "");
     div.style.top = (row * BROWSER_ROW_H) + "px";
     var time = document.createElement("span");
     time.className = "danmaku-browser-time";
@@ -1494,7 +1494,7 @@ iina.onMessage("danmaku-browser-data", function (data) {
   for (var i = 0; i < items.length; i++) {
     var item = items[i];
     if (!item || typeof item.t !== 'number' || !isFinite(item.t) || !item.text) continue;
-    browserItems.push({ t: item.t, text: item.text, blocked: !!item.blocked, merged: !!item.merged });
+    browserItems.push({ t: item.t, text: item.text, blocked: !!item.blocked, merged: !!item.merged, owner: !!item._owner });
   }
   if (!isDone) {
     // 传输中不渲染(done 时一次性渲染)


### PR DESCRIPTION
## Summary

Fixed-comment progressive merge (combo) on the plugin side, plus sidebar list improvements and danmaku-offset persistence removal. Requires the companion engine PR: karappo-yu/niconicomments-dom#2 (engine bundle `overlay/lib/niconicomments.min.js` in this repo is built from that branch).

## What's new

### Fixed-comment progressive combo (dedupe on)

With the dedupe switch enabled, **fixed comments (ue/shita) now merge progressively in the engine** instead of being pre-merged:

- The first `哈哈` displays normally; a second identical one arriving while it's still on screen turns it into `哈哈x2` in place (timer resets per arrival, subtle pop animation); `x3`, `x4`… follow
- If the previous one already disappeared, counting starts over
- Z-order: when the chain extends, the host covers scrolling comments that flew over it in the meantime
- Scrolling (naka) comments keep the existing one-shot merge (`xN` + pool color) — unchanged
- Dedupe off → everything renders as before (no engine chains built, `fixedCombo: false`)

Implementation: plugin main.js skips fixed comments in all four dedupe formats (nico-json v1/legacy, dandanplay, nico-xml, bilibili-xml) and passes `fixedCombo: danmakuDedupeEnabled` through every `load-danmaku` payload and `apply-settings`; overlay forwards it as the engine's `fixedCombo` config. Owner comments are exempt at every layer.

### Sidebar danmaku list now shows owner comments

Owner-thread (`fork === 'owner'`) comments were previously excluded from the filter-tab timeline. They now appear in the list with a **semi-transparent light-red row background**, and are excluded from all filtering: never marked as blocked (blocklist), never display-layer merged — listed verbatim, matching what the screen shows.

### Danmaku offset: per-video, no longer persisted

The offset value varies per video/danmaku file, so it no longer survives sessions:

- Removed `preferences.get/set` and the `danmakuTimeOffset` default in Info.json
- Resets to 0 on every video switch (`iina.file-loaded`), synced to overlay and sidebar input

### Engine bundle

`overlay/lib/niconicomments.min.js` updated to the fixedCombo build (overlay cache bumped to v10).

## Verification

- Node harness for plugin dedupe logic: 26 asserts (4 formats skip fixed / merge scroll, owner-thread pass-through, sidebar list owner inclusion + filter exemption)
- Full-overlay harness (real overlay pipeline, headless Chrome): 10 asserts including z-order promotion
- Engine-side harnesses live in karappo-yu/niconicomments-dom#2 (32 canvas + 19 CSS asserts)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of fixed-position comments during deduplication and progressive merging.
  * Added clearer visual identification for owner-posted comments in the danmaku browser.
  * Owner and fixed-comment metadata is now retained in browser listings.

* **Bug Fixes**
  * Danmaku time offsets now reset when loading a video and are no longer saved between sessions.
  * Fixed and owner comments are handled correctly without unintended blocking or merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->