### PR TITLE
feat: nico-json duration 时长自动检测 + 修复偏移引入的渲染时序 bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -86,7 +86,8 @@ var PLUGIN_I18N = {
     ddp_network_error: "DanDanPlay: network error",
     ddp_api_error: "DanDanPlay: API response error",
     ddp_no_comments: "DanDanPlay: no danmaku for this video",
-    ddp_load_failed: "DanDanPlay: failed to load danmaku"
+    ddp_load_failed: "DanDanPlay: failed to load danmaku",
+    duration_mismatch: "Duration mismatch with danmaku file: offset set to {offset}s"
   },
   ja: {
     menu_toggle: "\u30b3\u30e1\u30f3\u30c8\u8868\u793a\u3092\u5207\u308a\u66ff\u3048",
@@ -113,7 +114,8 @@ var PLUGIN_I18N = {
     ddp_network_error: "\u5f3e\u5f3ePlay: \u30cd\u30c3\u30c8\u30ef\u30fc\u30af\u30a8\u30e9\u30fc",
     ddp_api_error: "\u5f3e\u5f3ePlay: API\u5fdc\u7b54\u30a8\u30e9\u30fc",
     ddp_no_comments: "\u5f3e\u5f3ePlay: \u3053\u306e\u52d5\u753b\u306b\u30b3\u30e1\u30f3\u30c8\u304c\u3042\u308a\u307e\u305b\u3093",
-    ddp_load_failed: "\u5f3e\u5f3ePlay: \u30b3\u30e1\u30f3\u30c8\u306e\u8aad\u307f\u8fbc\u307f\u306b\u5931\u6557\u3057\u307e\u3057\u305f"
+    ddp_load_failed: "\u5f3e\u5f3ePlay: \u30b3\u30e1\u30f3\u30c8\u306e\u8aad\u307f\u8fbc\u307f\u306b\u5931\u6557\u3057\u307e\u3057\u305f",
+    duration_mismatch: "\u52d5\u753b\u306e\u9577\u3055\u304c\u30b3\u30e1\u30f3\u30c8\u30d5\u30a1\u30a4\u30eb\u3068\u4e00\u81f4\u3057\u307e\u305b\u3093: \u30aa\u30d5\u30bb\u30c3\u30c8\u3092 {offset}s \u306b\u81ea\u52d5\u8abf\u6574"
   },
   zh: {
     menu_toggle: "\u5207\u6362\u5f39\u5e55\u663e\u793a",
@@ -140,7 +142,8 @@ var PLUGIN_I18N = {
     ddp_network_error: "\u5f39\u5f39play: \u7f51\u7edc\u9519\u8bef",
     ddp_api_error: "\u5f39\u5f39play: API\u54cd\u5e94\u9519\u8bef",
     ddp_no_comments: "\u5f39\u5f39play: \u8be5\u89c6\u9891\u65e0\u5f39\u5e55",
-    ddp_load_failed: "\u5f39\u5f39play: \u52a0\u8f7d\u5f39\u5e55\u5931\u8d25"
+    ddp_load_failed: "\u5f39\u5f39play: \u52a0\u8f7d\u5f39\u5e55\u5931\u8d25",
+    duration_mismatch: "\u89c6\u9891\u65f6\u957f\u4e0e\u5f39\u5e55\u6587\u4ef6\u4e0d\u4e00\u81f4: \u5df2\u81ea\u52a8\u8bbe\u7f6e\u504f\u79fb {offset} \u79d2"
   }
 };
 
@@ -201,6 +204,9 @@ var danmakuFileList = {
 var danmakuCache = {};
 
 var nicoJsonTotalCount = 0;
+// 时长检测: nico-json main 线程的 duration(下载弹幕时原视频长度,秒)与当前视频时长的差值
+// null = 无检测结果(非 nico-json / 无 duration 字段 / 时长一致)
+var nicoJsonDurationDiff = null;
 var danmakuFilterOffset = 0;
 var danmakuFilterLimit = 0;
 var danmakuFilterDensity = 0;
@@ -319,6 +325,80 @@ function computeNicoJsonCount(encodedContent) {
     return count;
   } catch (e) {}
   return 0;
+}
+
+// 读取 nico-json 中 main 线程的 duration 字段(下载弹幕时原视频的长度,单位秒)
+function extractNicoJsonDuration(encodedContent) {
+  if (!encodedContent) return null;
+  try {
+    var raw = decodeURIComponent(encodedContent);
+    var data = JSON.parse(raw);
+    if (!Array.isArray(data)) return null;
+    for (var i = 0; i < data.length; i++) {
+      var th = data[i];
+      if (th && th.fork === 'main' && typeof th.duration === 'number' && isFinite(th.duration) && th.duration > 0) {
+        return th.duration;
+      }
+    }
+  } catch (e) {}
+  return null;
+}
+
+function formatSecondsShort(sec) {
+  var n = Math.round(sec * 10) / 10;
+  return (n % 1 === 0) ? String(Math.round(n)) : String(n);
+}
+
+// 时长检测: nico-json main 线程的 duration(下载弹幕时原视频长度,秒)与当前视频时长的差值
+// null = 无检测结果(非 nico-json / 无 duration 字段 / 时长一致)
+function setNicoJsonDurationDiff(diff) {
+  if (nicoJsonDurationDiff === diff) return;
+  nicoJsonDurationDiff = diff;
+  sidebar.postMessage("danmaku-state", { nicoJsonDurationDiff: diff });
+}
+
+function clearNicoJsonDuration() {
+  setNicoJsonDurationDiff(null);
+}
+
+// nico-json 加载时自动检测时长差: diff = 视频时长 - 弹幕源时长
+// |diff| < 0.5 视为一致(不做事);不一致则偏移设为 -diff(视频多出的片头部分)
+// 返回 true 表示本次比较有效(拿到了视频时长)
+function runDurationCompare(danmakuDuration) {
+  var videoDuration;
+  try { videoDuration = mpv.getNumber("duration"); } catch (e) { videoDuration = NaN; }
+  if (!videoDuration || !isFinite(videoDuration) || videoDuration <= 0) return false;
+  var diff = videoDuration - danmakuDuration;
+  if (Math.abs(diff) < 0.5) return true;
+  setNicoJsonDurationDiff(diff);
+  var offset = Math.round(-diff * 10) / 10;
+  applyDanmakuOffset(offset);
+  core.osd(t('duration_mismatch', { offset: formatSecondsShort(offset) }));
+  return true;
+}
+
+function checkNicoJsonDuration(encodedContent) {
+  setNicoJsonDurationDiff(null);
+  var danmakuDuration = extractNicoJsonDuration(encodedContent);
+  if (danmakuDuration === null) return;
+  if (runDurationCompare(danmakuDuration)) return;
+  // file-loaded 瞬间 mpv duration 可能还没就绪,延迟重试一次(仅当仍选中同一弹幕文件)
+  var savedPath = danmakuFileList.selectedPaths.length > 0 ? danmakuFileList.selectedPaths[0] : null;
+  setTimeout(function () {
+    if (savedPath && danmakuFileList.selectedPaths.length > 0 && danmakuFileList.selectedPaths[0] === savedPath) {
+      runDurationCompare(danmakuDuration);
+    }
+  }, 800);
+}
+
+// 加载弹幕后的 OSD: 若时长检测发现不一致,优先提醒(避免被"已加载"覆盖)
+function osdAfterDanmakuLoad(loadedName) {
+  if (nicoJsonDurationDiff !== null) {
+    var offset = Math.round(-nicoJsonDurationDiff * 10) / 10;
+    core.osd(t('duration_mismatch', { offset: formatSecondsShort(offset) }));
+  } else {
+    core.osd(t('loaded') + loadedName);
+  }
 }
 
 function sendDanmakuFilterInfo() {
@@ -1625,6 +1705,7 @@ function ddpAddToFileListAndLoad(episodeId, animeTitle, episodeTitle, converted,
     danmakuFileList.selectedPaths = [virtualPath];
     updateDanmakuStatus({ fileType: 'dandanplay', fileName: displayName, relativePath: 'DanDanPlay #' + episodeId, isLoaded: true });
     nicoJsonTotalCount = 0;
+    clearNicoJsonDuration();
     danmakuFilterOffset = 0;
     danmakuFilterLimit = 0;
     danmakuFilterDensity = 0;
@@ -1744,6 +1825,7 @@ function loadDanmakuForVideo(url) {
   ddpResetState();
   currentDanmakuStatus = { fileType: null, fileName: null, relativePath: null, isLoaded: false };
   nicoJsonTotalCount = 0;
+  clearNicoJsonDuration();
   danmakuFilterOffset = 0;
   danmakuFilterLimit = 0;
   danmakuFilterDensity = 0;
@@ -1842,8 +1924,10 @@ function loadLocalDanmaku(fileInfo) {
 
   if (fileType === 'nico-json') {
     nicoJsonTotalCount = computeNicoJsonCount(encodedContent);
+    checkNicoJsonDuration(encodedContent);
   } else {
     nicoJsonTotalCount = 0;
+    clearNicoJsonDuration();
   }
   danmakuFilterOffset = 0;
   danmakuFilterLimit = 0;
@@ -1873,7 +1957,7 @@ function loadLocalDanmaku(fileInfo) {
 
   if (overlayReady) {
     overlay.postMessage("load-danmaku", payload);
-    core.osd(t('loaded') + fileInfo.filename);
+    osdAfterDanmakuLoad(fileInfo.filename);
     setObserver(true);
   } else {
     pendingDanmaku = payload;
@@ -1909,7 +1993,7 @@ function markOverlayReady() {
     var pendingPath = danmakuFileList.selectedPaths.length > 0 ? danmakuFileList.selectedPaths[0] : "";
     var pendingInfo = pendingPath ? findDanmakuFileByPath(pendingPath) : null;
     var loadedName = pendingInfo ? pendingInfo.filename : (pendingPath ? pendingPath.split("/").pop() : "");
-    core.osd(t('loaded') + loadedName);
+    osdAfterDanmakuLoad(loadedName);
     pendingDanmaku = null;
     setObserver(true);
   } else if (danmakuEnabled && !core.status.idle && currentVideoUrl) {
@@ -1980,8 +2064,10 @@ function loadManualDanmakuFile(path) {
 
   if (manualFileType === 'nico-json') {
     nicoJsonTotalCount = computeNicoJsonCount(encodedContent);
+    checkNicoJsonDuration(encodedContent);
   } else {
     nicoJsonTotalCount = 0;
+    clearNicoJsonDuration();
   }
   danmakuFilterOffset = 0;
   danmakuFilterLimit = 0;
@@ -2007,7 +2093,7 @@ function loadManualDanmakuFile(path) {
 
   if (overlayReady) {
     overlay.postMessage("load-danmaku", manualPayload);
-    core.osd(t('loaded') + manualFileName);
+    osdAfterDanmakuLoad(manualFileName);
     ensureDanmakuEnabled();
   } else {
     pendingDanmaku = manualPayload;
@@ -2250,6 +2336,7 @@ function registerSidebarHandlers() {
       danmakuRelativePath: currentDanmakuStatus.relativePath,
       danmakuLoaded: currentDanmakuStatus.isLoaded,
       danmakuFilterDensity: danmakuFilterDensity,
+      nicoJsonDurationDiff: nicoJsonDurationDiff,
     });
     sidebar.postMessage("danmaku-file-list", danmakuFileList);
     sendDanmakuFilterInfo();
@@ -2311,8 +2398,10 @@ function registerSidebarHandlers() {
 
     if (fileType === 'nico-json') {
       nicoJsonTotalCount = computeNicoJsonCount(encodedContent);
+      checkNicoJsonDuration(encodedContent);
     } else {
       nicoJsonTotalCount = 0;
+      clearNicoJsonDuration();
     }
     danmakuFilterOffset = 0;
     danmakuFilterLimit = 0;
@@ -2339,7 +2428,7 @@ function registerSidebarHandlers() {
     };
 
     overlay.postMessage("load-danmaku", selectPayload);
-    core.osd(t('loaded') + (fileInfo ? fileInfo.filename : fileName));
+    osdAfterDanmakuLoad(fileInfo ? fileInfo.filename : fileName);
     ensureDanmakuEnabled();
   }
 
@@ -2371,7 +2460,7 @@ function registerSidebarHandlers() {
       if (content) {
         danmakuCache[path] = encodeContent(content);
         selectDanmakuFile(path); // 添加即加载: 不用再在列表里手动点选
-        core.osd(t('loaded') + fname);
+        osdAfterDanmakuLoad(fname);
       } else {
         core.osd(t('read_failed_name') + fname);
         sidebar.postMessage("danmaku-file-error", { path: path, message: t('read_failed') });

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -11,6 +11,6 @@
        插件重载后 overlay 仍运行旧 JS(曾导致过滤 tab 收不到任何数据) -->
   <script src="lib/niconicomments.min.js?v=10"></script>
   <script src="input.js?v=10"></script>
-  <script src="main.js?v=10"></script>
+  <script src="main.js?v=11"></script>
 </body>
 </html>

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -11,6 +11,6 @@
        插件重载后 overlay 仍运行旧 JS(曾导致过滤 tab 收不到任何数据) -->
   <script src="lib/niconicomments.min.js?v=10"></script>
   <script src="input.js?v=10"></script>
-  <script src="main.js?v=11"></script>
+  <script src="main.js?v=12"></script>
 </body>
 </html>

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -317,7 +317,9 @@ iina.onMessage("time-update", (data) => {
   lastTime = t;
   if (isSeek && niconiComments) {
     niconiComments.clear();
-    drawCanvasAtVpos(t, true);
+    // 必须用偏移后时间: 裸视频时间会在负偏移时把本该延后的弹幕提前生成,
+    // CSS 模式弹幕是 DOM 动画,生成后会完整飘完一遍再出现第二次(重复)
+    drawCanvasAtVpos(canvasGetCurrentTime() * 100, true);
   }
   startCanvasLoop();
 });

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -390,7 +390,9 @@ iina.onMessage("resize", () => {
 });
 
 iina.onMessage("pause-state", (data) => {
-  const anchoredTime = canvasGetCurrentTime();
+  // canvasGetCurrentTime() 返回的是含偏移的时间,而锚点存的是裸视频时间——
+  // 回写前必须剥离偏移,否则下次读取会二次叠加偏移
+  const anchoredTime = canvasGetCurrentTime() - danmakuTimeOffsetSec;
   isPaused = !!data.paused;
   canvasIsPlaying = !isPaused;
   canvasSyncAnchor(anchoredTime);
@@ -406,7 +408,8 @@ iina.onMessage("pause-state", (data) => {
 });
 
 iina.onMessage("playback-speed", (data) => {
-  const anchoredTime = canvasGetCurrentTime();
+  // 同 pause-state: 锚点存裸视频时间,回写前剥离偏移
+  const anchoredTime = canvasGetCurrentTime() - danmakuTimeOffsetSec;
   playbackSpeed = data && data.speed ? data.speed : 1.0;
   canvasSyncAnchor(anchoredTime);
   // 通知 CSS 渲染器:速度变化时重设滚动动画时长(1x 无操作)

--- a/sidebar/index.html
+++ b/sidebar/index.html
@@ -257,6 +257,7 @@
         <input type="number" id="danmaku-offset-input" value="0" min="-30" max="30" step="0.5"
           style="margin-left:auto;width:72px" />
       </div>
+      <div id="duration-mismatch-hint" class="dandanplay-error" style="display:none"></div>
 
       <!-- Font Family -->
       <div class="control-row" style="margin-top:16px">
@@ -346,7 +347,7 @@
     </div>
 
   </div>
-  <script src="index.js?v=48"></script>
+  <script src="index.js?v=49"></script>
 </body>
 
 </html>

--- a/sidebar/index.js
+++ b/sidebar/index.js
@@ -16,6 +16,7 @@ var commentLimitValue = document.getElementById("comment-limit-value");
 var speedSlider = document.getElementById("speed-slider");
 var speedValue = document.getElementById("speed-value");
 var offsetInput = document.getElementById("danmaku-offset-input");
+var durationMismatchHint = document.getElementById("duration-mismatch-hint");
 var fontSelect = document.getElementById("danmaku-font-select");
 var fontCustomRow = document.getElementById("danmaku-font-custom-row");
 var fontCustomInput = document.getElementById("danmaku-font-custom");
@@ -85,6 +86,7 @@ var state = {
   commentLimit: 0,
   scrollSpeed: 1.0,
   danmakuOffsetSeconds: 0,
+  nicoJsonDurationDiff: null,
   danmakuFontFamily: "",
   danmakuFontWeight: "400",
   stylePreset: "nico",
@@ -200,6 +202,9 @@ var i18n = {
     style_preset: "Style Preset",
     style_balanced: "Balanced",
     danmaku_offset: "Danmaku Offset (s)",
+    duration_diff_label: "Duration diff:",
+    duration_diff_longer: "video is {diff}s longer than danmaku source",
+    duration_diff_shorter: "video is {diff}s shorter than danmaku source",
     danmaku_font_family: "Font Family",
     danmaku_font_custom: "Custom Font",
     danmaku_font_weight: "Weight",
@@ -252,6 +257,9 @@ var i18n = {
     style_preset: "\u30b9\u30bf\u30a4\u30eb\u30d7\u30ea\u30bb\u30c3\u30c8",
     style_balanced: "\u30d0\u30e9\u30f3\u30b9",
     danmaku_offset: "\u30b3\u30e1\u30f3\u30c8\u6642\u9593\u30aa\u30d5\u30bb\u30c3\u30c8 (\u79d2)",
+    duration_diff_label: "\u6642\u9593\u5dee:",
+    duration_diff_longer: "\u52d5\u753b\u304c\u30b3\u30e1\u30f3\u30c8\u30bd\u30fc\u30b9\u3088\u308a {diff}\u79d2\u9577\u3044",
+    duration_diff_shorter: "\u52d5\u753b\u304c\u30b3\u30e1\u30f3\u30c8\u30bd\u30fc\u30b9\u3088\u308a {diff}\u79d2\u77ed\u3044",
     danmaku_font_family: "\u30d5\u30a9\u30f3\u30c8",
     danmaku_font_custom: "\u30ab\u30b9\u30bf\u30e0\u30d5\u30a9\u30f3\u30c8",
     danmaku_font_weight: "\u592a\u3055",
@@ -304,6 +312,9 @@ var i18n = {
     style_preset: "\u98ce\u683c\u9884\u8bbe",
     style_balanced: "\u5e73\u8861",
     danmaku_offset: "\u5f39\u5e55\u65f6\u95f4\u504f\u79fb (\u79d2)",
+    duration_diff_label: "\u5f53\u524d\u5dee\u503c:",
+    duration_diff_longer: "\u89c6\u9891\u6bd4\u5f39\u5e55\u6e90\u957f {diff} \u79d2",
+    duration_diff_shorter: "\u89c6\u9891\u6bd4\u5f39\u5e55\u6e90\u77ed {diff} \u79d2",
     danmaku_font_family: "\u5b57\u4f53",
     danmaku_font_custom: "\u81ea\u5b9a\u4e49\u5b57\u4f53",
     danmaku_font_weight: "\u7c97\u7ec6",
@@ -374,6 +385,21 @@ function updateOffsetUI() {
   if (offsetInput) {
     offsetInput.value = state.danmakuOffsetSeconds;
   }
+}
+
+function updateDurationDiffUI() {
+  if (!durationMismatchHint) return;
+  var diff = state.nicoJsonDurationDiff;
+  if (diff === null || diff === undefined || !isFinite(diff)) {
+    durationMismatchHint.style.display = "none";
+    durationMismatchHint.textContent = "";
+    return;
+  }
+  var abs = Math.round(Math.abs(diff) * 10) / 10;
+  var absStr = (abs % 1 === 0) ? String(Math.round(abs)) : String(abs);
+  var msgKey = diff > 0 ? 'duration_diff_longer' : 'duration_diff_shorter';
+  durationMismatchHint.textContent = t('duration_diff_label') + ' ' + t(msgKey).replace('{diff}', absStr);
+  durationMismatchHint.style.display = "";
 }
 
 var FONT_PRESETS = {
@@ -468,6 +494,7 @@ function updateUI() {
   if (canvasRendererToggle) canvasRendererToggle.checked = state.useCanvasRenderer;
   if (danmakuForceSimplifiedToggle) danmakuForceSimplifiedToggle.checked = state.danmakuForceSimplified; 
   updateOffsetUI();
+  updateDurationDiffUI();
   updateFontUI();
   syncStylePresetUI();
   updateFilterUI();
@@ -901,6 +928,7 @@ iina.onMessage("danmaku-state", function (data) {
   if (data.commentLimit !== undefined) state.commentLimit = data.commentLimit;
   if (data.scrollSpeed !== undefined) state.scrollSpeed = data.scrollSpeed;
   if (data.danmakuTimeOffsetSec !== undefined) state.danmakuOffsetSeconds = data.danmakuTimeOffsetSec;
+  if (data.nicoJsonDurationDiff !== undefined) state.nicoJsonDurationDiff = data.nicoJsonDurationDiff;
   if (data.danmakuFontFamily !== undefined) state.danmakuFontFamily = data.danmakuFontFamily;
   if (data.danmakuFontWeight !== undefined) state.danmakuFontWeight = data.danmakuFontWeight;
   if (data.stylePreset !== undefined) state.stylePreset = data.stylePreset;


### PR DESCRIPTION
## 功能: nico-json duration 时长自动检测

加载 nico-json 弹幕时自动检测 `fork === "main"` 线程的 `duration` 字段(下载弹幕时原视频长度,秒),与当前视频时长对比:

- `|diff| < 0.5s` 视为一致,不做处理
- 不一致时自动设置偏移: `offset = round(-diff * 10) / 10`(视频比弹幕源长 5s → 偏移 -5)
- OSD 提醒,优先于"已加载"提示(避免被覆盖)
- sidebar 偏移输入框下方红字显示当前时长差值
- 切换视频/切换弹幕格式/DanDanPlay 加载时清除状态

## 修复 1: seek 强绘漏掉弹幕偏移

负偏移下第 0 秒出现本该被偏移掉的弹幕、之后重复出现(仅 CSS 模式可见)。

**根因**: `time-update` 的 seek 分支用裸视频时间强绘,其他绘制路径都走偏移后时间。切换视频时首个时间更新被判定为 seek,用裸时间 0 生成弹幕源 0~5s 的弹幕;CSS 模式弹幕是 DOM + CSS 动画,生成后完整飘完一遍,随后渲染循环用正确时间又生成一次 → 重复。canvas 每帧整块重画,错误帧立刻被覆盖。

**修复**: seek 强绘改用偏移后时间。

## 修复 2: 暂停/变速时偏移二次叠加

暂停状态下缩放窗口,窗口大小确定后弹幕变成偏移应用前的状态;点播放后 CSS 模式偏移前后弹幕混在一起。

**根因**: 时间锚点约定存裸视频时间,读取时统一加偏移;但 pause-state/playback-speed 处理器把含偏移的时间读出来原样写回裸时间锚点,之后每次读取二次叠加偏移(画在 视频时间 + 2×偏移)。拖动过程无重绘(引擎 ResizeObserver 纯 CSS 缩放)所以看起来正常,松手触发 overlay 重绘才暴露。偏移为 0 时 2×0=0 不可见,所以偏移功能(#7)上线以来一直存在,本次 duration 自动偏移让其显形。

**修复**: 暂停/变速回写锚点前剥离偏移。

## 测试

- duration 检测: 23/23(提取/容差/偏移计算/OSD 优先级/清除时机/状态同步)
- seek 偏移: 修复前 FAIL(vpos=20 裸时间)→ 修复后 3/3(seek/渲染循环/resize 三条路径时间基准核对)
- 暂停缩放偏移: 修复前 0/3(画在 5000,正确 5500)→ 修复后 3/3(含变速叠加场景)
- 去重回归: 26/26
- 真实示例文件验证: duration=1440,模拟视频长 5s → 偏移 -5

## 缓存版本

- overlay: main.js v=12
- sidebar: index.js/index.css v=49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized duration-mismatch notices in English, Japanese, and Chinese.
  - Automatically adjusts danmaku timing when the source and video durations differ.
  - Sidebar now displays whether the video is longer or shorter, including the duration difference.
  - Added a retry when video duration information is temporarily unavailable.

- **Bug Fixes**
  - Improved danmaku synchronization during seeking, pausing, and playback-speed changes.
  - Prevented timing offsets from accumulating across playback interactions.
  - Reset duration information when switching videos or sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->