### PR TITLE
feat: naka danmaku dedupe moved to engine, merged comments keep native style with colored xN suffix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,15 @@ Three data paths in `overlay/main.js`:
 
 `set-danmaku-offset` → `applyDanmakuOffset()` (persist + forward). Overlay adds `danmakuTimeOffsetSec` inside `canvasGetCurrentTime()` (base time + offset), so both CSS and Canvas modes shift instantly. Sidebar: number input (±30s, step 0.5) and A/D keys (only when sidebar has focus; step = |current offset|, fallback 1 — quirky but works); both send `set-danmaku-offset`.
 
+### Danmaku Deduplication (engine-side render merge, plugin-side list merge)
+
+Dedup is split across two sides with the SAME window semantics (greedy from earliest, first-in-group wins, text + `xN` suffix, other members hidden):
+
+- **Render side — engine**: `fixedCombo` (fixed ue/shita progressive combo) + `nakaDedupeWindow` (scroll naka static window merge, 1/100s units, 0 = off). The engine merges AFTER parsing and BEFORE `getCommentPos`, so the merged host width (with `xN`) participates in lane assignment. Naka host keeps its native body style; only the `xN` suffix gets a random color (`comboSuffix`/`comboSuffixColor`, rendered as colored span in CSS mode / dual-color draw in Canvas mode). Owner (fork owner), fixed comments, and empty text never participate. Naka groups are static — no per-frame updates (unlike fixedCombo).
+- **List side — plugin**: `mergeDuplicateItems()` in `main.js` runs only inside `buildDanmakuBrowserList()` (display merge; blocked items merged separately, owners/fixed excluded).
+- `getEffectiveContent()` does NOT dedupe anymore — it applies filters (slices/density/simplified/blocklist) only; the dedupe window reaches the overlay via `nakaDedupeWindow: danmakuDedupeWindow * 100` in every `load-danmaku` payload (next to `fixedCombo: danmakuDedupeEnabled`).
+- Removed render-side plugin pipeline: `dedupeContent`/`dedupeNicoJson`/`pickMergeColor`/`MERGE_COLORS`/`encodeXmlText` no longer exist. `isFixedCommentCommands`/`isFixedCommentMail` remain (used by the list).
+
 ## Dandanplay Network Danmaku
 
 ### Auto-Match Flow

--- a/main.js
+++ b/main.js
@@ -594,6 +594,7 @@ function applyDanmakuFilter(offset, limit) {
     danmakuFontWeight: danmakuFontWeight,
     preservePosition: true,
     fixedCombo: danmakuDedupeEnabled,
+    nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
   });
   sendDanmakuFilterInfo();
 }
@@ -708,10 +709,10 @@ function isBlockedText(text) {
 }
 
 // ── 弹幕去重(时间窗内重复文本合并) ───────────────────────────────────
-// 输入为已含 .t(1/100s) 与 .text 的对象数组(时间无需有序,内部按 t 排序);
-// 窗口 windowMs 内文本相同的弹幕合并为一条——保留组内最早对象(时间=t),
-// 其 .text 原地改为 "原文✖️N";被合并对象从输出消失。调用方通过对象引用
-// 判断保留/删除。与屏蔽词/简繁共用同一变换序列,保证 overlay 与列表一致。
+// 渲染侧去重已下放引擎(nakaDedupeWindow 静态合并,见 resendDanmakuToOverlay);
+// 本函数仅用于 sidebar 列表的展示层合并(与引擎相同的窗口语义: 最早者胜,
+// 文本追加 xN,时间窗内同文本合成一条)。输入为已含 .t(1/100s) 与 .text 的
+// 对象数组(时间无需有序,内部按 t 排序);被合并对象从输出消失。
 function mergeDuplicateItems(items, windowMs) {
   if (!items || items.length === 0) return items;
   if (!(windowMs > 0)) return items;
@@ -738,7 +739,7 @@ function mergeDuplicateItems(items, windowMs) {
         j++;
       }
       if (count > 1) {
-        // 合并标记(调用方据此给新弹幕加颜色指令);分隔符用 x(✖ 太粗,且不带
+        // 合并标记(调用方据此识别合并弹幕);分隔符用 x(✖ 太粗,且不带
         // 变体选择符时才按文本渲染)
         first._mergeCount = count;
         first.text = first.text + 'x' + count;
@@ -751,202 +752,13 @@ function mergeDuplicateItems(items, windowMs) {
   return out;
 }
 
-// XML 文本转义(合并文本重建行时用;与 decodeXmlText 互逆)
-function encodeXmlText(text) {
-  return String(text)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-}
-
-// 合并弹幕颜色池(鲜艳色,视觉可区分;nico 经典色系)
-var MERGE_COLORS = [
-  { name: 'red',    hex: '#ff0000', dec: 16711680 },
-  { name: 'pink',   hex: '#ff8080', dec: 16744576 },
-  { name: 'orange', hex: '#ffcc00', dec: 16763904 },
-  { name: 'yellow', hex: '#ffff00', dec: 16776960 },
-  { name: 'green',  hex: '#00ff00', dec: 65280 },
-  { name: 'cyan',   hex: '#00ffff', dec: 65535 },
-  { name: 'blue',   hex: '#0000ff', dec: 255 },
-  { name: 'purple', hex: '#800080', dec: 8388736 }
-];
-function pickMergeColor(text) {
-  if (text) {
-    // 按文本 hash 稳定选色: 同一合并文本每次重建颜色不变(重发/改设置不闪色),
-    // 不同文本按 hash 分散到色池
-    var h = 0;
-    for (var i = 0; i < text.length; i++) {
-      h = (h * 31 + text.charCodeAt(i)) | 0;
-    }
-    return MERGE_COLORS[Math.abs(h) % MERGE_COLORS.length];
-  }
-  return MERGE_COLORS[Math.floor(Math.random() * MERGE_COLORS.length)];
-}
-
-// 固定弹幕(ue/shita)识别: 预合并跳过固定弹幕,它们由渲染引擎做渐进合并(combo)
+// 固定弹幕(ue/shita)识别: 列表展示层合并跳过固定弹幕,它们由渲染引擎做渐进合并(combo)
 function isFixedCommentCommands(cmds) {
   return Array.isArray(cmds) && (cmds.indexOf('ue') !== -1 || cmds.indexOf('shita') !== -1);
 }
 function isFixedCommentMail(mail) {
   if (typeof mail !== 'string') return false;
   return /(^|\s)(ue|shita)(\s|$)/.test(mail);
-}
-
-// nico-json 去重: 每个 thread 的 comments 内合并(保留组内最早 comment 的全部字段)
-function dedupeNicoJson(encodedContent) {
-  if (!(danmakuDedupeWindow > 0)) return encodedContent;
-  var rawStr;
-  try { rawStr = decodeURIComponent(encodedContent); } catch (e) { return encodedContent; }
-  var data;
-  try { data = JSON.parse(rawStr); } catch (e) { return encodedContent; }
-  if (!Array.isArray(data)) return encodedContent;
-  var windowMs = danmakuDedupeWindow * 100;
-  var changed = false;
-  var filteredData = [];
-  for (var i = 0; i < data.length; i++) {
-    var thread = data[i];
-    // owner 线程(fork==='owner')压根不进过滤器: 原样透传,不参与去重
-    if (thread && thread.fork === 'owner') { filteredData.push(thread); continue; }
-    // legacy nico-json(thread.chat)与现代表格(thread.comments)都处理
-    var srcComments = thread ? (Array.isArray(thread.comments) ? thread.comments : (Array.isArray(thread.chat) ? thread.chat : null)) : null;
-    if (!srcComments) { filteredData.push(thread); continue; }
-    var entries = [];
-    for (var j = 0; j < srcComments.length; j++) {
-      var c = srcComments[j];
-      if (!c) { entries.push({ t: 0, text: '', _c: c, _skip: true }); continue; }
-      var t = c.vposMs !== undefined ? Math.round(c.vposMs / 10) : (typeof c.vpos === 'number' ? Math.round(c.vpos) : NaN);
-      var text = c.body !== undefined ? c.body : c.content;
-      if (!isFinite(t) || !text) { entries.push({ t: 0, text: '', _c: c, _skip: true }); continue; }
-      // 固定弹幕(ue/shita)跳过预合并: 由渲染引擎做渐进合并(x2→x3),预合并会抢走它的数据
-      if (isFixedCommentCommands(c.commands) || isFixedCommentMail(c.mail)) {
-        entries.push({ t: t, text: text, _c: c, _skip: true });
-        continue;
-      }
-      entries.push({ t: t, text: text, _c: c });
-    }
-    var merged = mergeDuplicateItems(entries, windowMs);
-    var newComments = [];
-    for (var k = 0; k < merged.length; k++) {
-      var e = merged[k];
-      if (e._skip) { newComments.push(e._c); continue; }
-      if (e._mergeCount > 1) {
-        // 合并出的新弹幕: commands 数组追加随机颜色命令(v1 格式无 mail 字段,
-        // commands 直接作为引擎 mail 解析,颜色名经 config.colors 生效)
-        var mc = pickMergeColor(e.text);
-        if (!Array.isArray(e._c.commands)) e._c.commands = [];
-        e._c.commands.push(mc.name);
-      }
-      if (e._c.body !== undefined) e._c.body = e.text;
-      else e._c.content = e.text;
-      newComments.push(e._c);
-    }
-    if (newComments.length !== srcComments.length) {
-      changed = true;
-      var newObj = {};
-      for (var p in thread) { if (thread.hasOwnProperty(p)) newObj[p] = thread[p]; }
-      newObj[Array.isArray(thread.comments) ? 'comments' : 'chat'] = newComments;
-      newObj.commentCount = newComments.length;
-      filteredData.push(newObj);
-    } else {
-      filteredData.push(thread);
-    }
-  }
-  if (!changed) return encodedContent;
-  return encodeContent(JSON.stringify(filteredData));
-}
-
-// 非 nico-json 去重: dandanplay 解析合并;XML(bilibili <d> / nico <chat>)行级合并
-function dedupeContent(encodedContent, ft) {
-  if (!(danmakuDedupeWindow > 0)) return encodedContent;
-  var rawStr;
-  try { rawStr = decodeURIComponent(encodedContent); } catch (e) { return encodedContent; }
-  var windowMs = danmakuDedupeWindow * 100;
-  if (ft === 'dandanplay') {
-    var list;
-    try { list = JSON.parse(rawStr); } catch (e) { return encodedContent; }
-    if (!Array.isArray(list)) return encodedContent;
-    var entries = [];
-    for (var i = 0; i < list.length; i++) {
-      var d = list[i];
-      if (!d || typeof d.t !== 'number' || !isFinite(d.t) || !d.text) { entries.push({ t: 0, text: '', _d: d, _skip: true }); continue; }
-      // 固定弹幕(ue/shita)跳过预合并: 由渲染引擎做渐进合并
-      if (isFixedCommentCommands(d._commands)) { entries.push({ t: Math.round(d.t), text: d.text, _d: d, _skip: true }); continue; }
-      entries.push({ t: Math.round(d.t), text: d.text, _d: d });
-    }
-    var merged = mergeDuplicateItems(entries, windowMs);
-    var out = [];
-    for (var k = 0; k < merged.length; k++) {
-      var e = merged[k];
-      if (e._skip) { out.push(e._d); continue; }
-      if (e._mergeCount > 1 && Array.isArray(e._d._commands)) {
-        // 合并出的新弹幕: 颜色命令替换为随机颜色(无颜色命令则追加)
-        var mc = pickMergeColor(e.text);
-        var hasColor = false;
-        for (var ci = 0; ci < e._d._commands.length; ci++) {
-          if (e._d._commands[ci].charAt(0) === '#') {
-            e._d._commands[ci] = mc.hex;
-            hasColor = true;
-            break;
-          }
-        }
-        if (!hasColor) e._d._commands.push(mc.hex);
-      }
-      e._d.text = e.text;
-      out.push(e._d);
-    }
-    if (out.length === list.length) return encodedContent;
-    return encodeContent(JSON.stringify(out));
-  }
-  // 用 ft 判断格式(内容嗅探 '<chat' 会误判含 <chatserver> 头部的 bilibili XML)
-  var re = ft === 'nico-xml'
-    ? /(<chat\b[^>]*>)([\s\S]*?)(<\/chat>)/g
-    : /(<d\s+p="[^"]*"[^>]*>)([\s\S]*?)(<\/d>)/g;
-  var lines = []; // {t, text, head, tail, full, start}
-  var m;
-  while ((m = re.exec(rawStr)) !== null) {
-    var t = m[1].indexOf('vpos="') !== -1
-      ? parseInt((m[1].match(/vpos="(\d+)"/) || [0, 0])[1], 10) || 0
-      : Math.round((parseFloat((m[1].match(/p="([^"]*)"/) || [0, '0'])[1].split(',')[0]) || 0) * 100);
-    // 固定弹幕(ue/shita / p mode 4・5)跳过预合并: 由渲染引擎做渐进合并
-    var isFixed = ft === 'nico-xml'
-      ? isFixedCommentMail((m[1].match(/mail="([^"]*)"/) || [0, ''])[1])
-      : [4, 5].indexOf(parseInt((m[1].match(/p="([^"]*)"/) || [0, '0'])[1].split(',')[1], 10)) !== -1;
-    // start = 本行在原始串中的位置: 重建时按序推进,无需重扫/线性查找(O(n))
-    lines.push({ t: t, text: decodeXmlText(m[2]), head: m[1], tail: m[3], full: m[0], start: m.index, _skip: isFixed || undefined });
-  }
-  if (lines.length === 0) return encodedContent;
-  var merged = mergeDuplicateItems(lines, windowMs);
-  var kept = new Set();
-  for (var i2 = 0; i2 < merged.length; i2++) kept.add(merged[i2]);
-  if (kept.size === lines.length) return encodedContent;
-  // 重建: 按原始顺序推进——每行输出它前面那段原始内容(头部等非弹幕内容),
-  // 保留的行重建(合并标色/文本),被合并掉的行自然跳过。O(n)。
-  var parts = [];
-  var last = 0;
-  for (var li = 0; li < lines.length; li++) {
-    var line = lines[li];
-    parts.push(rawStr.slice(last, line.start));
-    if (kept.has(line)) {
-      var head = line.head;
-      if (line._mergeCount > 1) {
-        // 合并出的新弹幕: p 属性第 4 段(颜色)替换为随机颜色
-        var pm = head.match(/p="([^"]*)"/);
-        if (pm) {
-          var pParts = pm[1].split(',');
-          if (pParts.length >= 4) {
-            pParts[3] = String(pickMergeColor(line.text).dec);
-            head = head.replace(pm[1], pParts.join(','));
-          }
-        }
-      }
-      parts.push(head + encodeXmlText(line.text) + line.tail);
-    }
-    last = line.start + line.full.length;
-  }
-  parts.push(rawStr.slice(last));
-  return encodeContent(parts.join(''));
 }
 
 // nico-json: 过滤所有 thread 的 comments(owner 线程 fork==='owner' 压根不进过滤器)
@@ -1033,7 +845,8 @@ function filterBlockedContent(encodedContent, ft) {
 // 单源内容出口: 按当前设置返回"最终内容"(URI 编码形式)。
 // overlay 的 load-danmaku 与 sidebar 过滤列表都从这里取数,保证两边拿到
 // 完全同一份数据——nico-json 应用 offset/limit/密度切片;其他格式应用强制简体转换;
-// 屏蔽词开启时两者都再经过屏蔽词过滤;去重开启时最后合并重复弹幕。
+// 屏蔽词开启时两者都再经过屏蔽词过滤。去重不在本层做: 渲染侧由引擎
+// nakaDedupeWindow 配置静态合并,列表侧由 buildDanmakuBrowserList 自行合并。
 function getEffectiveContent(path) {
   var encodedContent = danmakuCache[path];
   if (!encodedContent) return null;
@@ -1042,7 +855,6 @@ function getEffectiveContent(path) {
   if (ft === 'nico-json') {
     out = applyNicoJsonFilters(encodedContent); // 切片/密度(无过滤时原样返回)
     if (danmakuBlocklistEnabled) out = filterBlockedNicoJson(out);
-    if (danmakuDedupeEnabled) out = dedupeNicoJson(out);
     return out;
   }
   if (danmakuForceSimplified && ensureBrowserSimplifier()) {
@@ -1055,7 +867,6 @@ function getEffectiveContent(path) {
     out = encodedContent;
   }
   if (danmakuBlocklistEnabled) out = filterBlockedContent(out, ft);
-  if (danmakuDedupeEnabled) out = dedupeContent(out, ft);
   return out;
 }
 
@@ -1231,7 +1042,8 @@ function resendDanmakuToOverlay() {
     danmakuFontFamily: danmakuFontFamily,
     danmakuFontWeight: danmakuFontWeight,
     preservePosition: true,
-    fixedCombo: danmakuDedupeEnabled
+    fixedCombo: danmakuDedupeEnabled,
+    nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0
   });
 }
 
@@ -1734,6 +1546,7 @@ function ddpAddToFileListAndLoad(episodeId, animeTitle, episodeTitle, converted,
       scrollSpeed: scrollSpeed,
       preservePosition: true,
       fixedCombo: danmakuDedupeEnabled,
+      nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
     };
     if (overlayReady) {
       overlay.postMessage("load-danmaku", payload);
@@ -1960,6 +1773,7 @@ function loadLocalDanmaku(fileInfo) {
     scrollSpeed: scrollSpeed,
     preservePosition: true,
     fixedCombo: danmakuDedupeEnabled,
+    nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
   };
 
   if (overlayReady) {
@@ -1990,7 +1804,8 @@ function markOverlayReady() {
     danmakuFontFamily: danmakuFontFamily,
     danmakuFontWeight: danmakuFontWeight,
     danmakuForceSimplified: danmakuForceSimplified,
-    fixedCombo: danmakuDedupeEnabled
+    fixedCombo: danmakuDedupeEnabled,
+    nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0
   });
 
   if (pendingDanmaku) {
@@ -2092,6 +1907,7 @@ function loadManualDanmakuFile(path) {
     scrollSpeed: scrollSpeed,
     preservePosition: true,
     fixedCombo: danmakuDedupeEnabled,
+    nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
   };
 
   if (overlayReady) {
@@ -2433,6 +2249,7 @@ function registerSidebarHandlers() {
       scrollSpeed: scrollSpeed,
       preservePosition: true,
       fixedCombo: danmakuDedupeEnabled,
+      nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
     };
 
     overlay.postMessage("load-danmaku", selectPayload);

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -9,8 +9,8 @@
   <canvas id="niconicomments-canvas"></canvas>
   <!-- ?v= 版本参数: WKWebView 会按 URL 缓存 file:// 脚本子资源,不加参数会导致
        插件重载后 overlay 仍运行旧 JS(曾导致过滤 tab 收不到任何数据) -->
-  <script src="lib/niconicomments.min.js?v=10"></script>
-  <script src="input.js?v=10"></script>
+  <script src="lib/niconicomments.min.js?v=11"></script>
+  <script src="input.js?v=11"></script>
   <script src="main.js?v=12"></script>
 </body>
 </html>

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -9,8 +9,8 @@
   <canvas id="niconicomments-canvas"></canvas>
   <!-- ?v= 版本参数: WKWebView 会按 URL 缓存 file:// 脚本子资源,不加参数会导致
        插件重载后 overlay 仍运行旧 JS(曾导致过滤 tab 收不到任何数据) -->
-  <script src="lib/niconicomments.min.js?v=11"></script>
+  <script src="lib/niconicomments.min.js?v=12"></script>
   <script src="input.js?v=11"></script>
-  <script src="main.js?v=12"></script>
+  <script src="main.js?v=13"></script>
 </body>
 </html>

--- a/overlay/lib/niconicomments.min.js
+++ b/overlay/lib/niconicomments.min.js
@@ -1466,6 +1466,11 @@ Released under the MIT License.
 			flashScriptChar: isValidFlashScriptChar,
 			flashThreshold: (i) => isFiniteNumberInRange(i, { max: MAX_UNIX_TIME_SECONDS }),
 			fixedCombo: (i) => typeof i === "boolean",
+			nakaDedupeWindow: (i) => isFiniteNumberInRange(i, {
+				min: 0,
+				max: MAX_COMMENT_RANGE,
+				integer: true
+			}),
 			fontSize: isBoundedFontSizeConfig,
 			fpsInterval: (i) => isFiniteNumberInRange(i, { max: MAX_COMMENT_RANGE }),
 			hideCommentOrder: isHideCommentOrder,
@@ -2945,6 +2950,58 @@ Released under the MIT License.
 		}
 		return lo;
 	};
+	/**
+	* 滚动弹幕(naka)窗口去重: 静态合并。
+	*
+	* 与插件侧 mergeDuplicateItems 语义一致: 按文本精确分组(不区分字号/位置),
+	* 时间升序后贪心分组——组内成员与最早者的 vpos 差 ≤ windowVpos;
+	* 宿主(组内最早)文本追加 xN 后缀并随机着色,其余成员标记 invisible。
+	* 分组在位置解析前一次性完成,窗口组是静态的,无需逐帧更新(与 fixedCombo 不同)。
+	* owner / 固定弹幕(ue/shita) / 空文本不参与。
+	*
+	* @param comments 全部评论实例(createCommentInstance 之后、getCommentPos 之前)
+	* @param windowVpos 去重窗口(1/100s;0 或负值 = 关闭)
+	*/
+	const applyNakaDedupe = (comments, windowVpos) => {
+		if (!(windowVpos > 0)) return;
+		const buckets = /* @__PURE__ */ new Map();
+		for (const comment of comments) {
+			if (!comment || comment.invisible || comment.owner) continue;
+			if (comment.loc !== "naka") continue;
+			const base = comment.content;
+			if (typeof base !== "string" || base.length === 0) continue;
+			const list = buckets.get(base);
+			if (list) list.push(comment);
+			else buckets.set(base, [comment]);
+		}
+		for (const [, list] of buckets) {
+			if (list.length < 2) continue;
+			list.sort((a, b) => a.vpos - b.vpos || a.index - b.index);
+			let i = 0;
+			while (i < list.length) {
+				const first = list[i];
+				if (!first) break;
+				let count = 1;
+				let j = i + 1;
+				while (j < list.length) {
+					const item = list[j];
+					if (!item || item.vpos - first.vpos > windowVpos) break;
+					count++;
+					j++;
+				}
+				if (count > 1) {
+					first.content = `${first.content}x${count}`;
+					first.comment.comboSuffix = `x${count}`;
+					first.comment.comboSuffixColor = pickRandomComboColor();
+					for (let k = i + 1; k < j; k++) {
+						const member = list[k];
+						if (member) member.comment.invisible = true;
+					}
+				}
+				i = j;
+			}
+		}
+	};
 	//#endregion
 	//#region src/utils/sort.ts
 	/**
@@ -3506,6 +3563,7 @@ Released under the MIT License.
 		MAX_PARSED_COMMAND_MAIL_ENTRIES: () => 64,
 		RangeCacheContext: () => RangeCacheContext,
 		addHTML5PartToResult: () => addHTML5PartToResult,
+		applyNakaDedupe: () => applyNakaDedupe,
 		arrayEqual: () => arrayEqual,
 		arrayPush: () => arrayPush,
 		buildAtButtonComment: () => buildAtButtonComment,
@@ -5587,6 +5645,12 @@ Released under the MIT License.
 			* 同一テキストの固定コメントが先行コメント表示中に到達すると x2, x3… と段階的に更新される
 			*/
 			fixedCombo: false,
+			/**
+			* 滚动弹幕(naka)窗口去重: 同文本滚动弹幕在 windowVpos(1/100s)窗口内
+			* 静态合并为一条(最早者胜),宿主文本追加 xN 后缀并随机着色,成员隐藏。
+			* 0 = 关闭。owner / 固定弹幕(ue/shita)不参与。
+			*/
+			nakaDedupeWindow: 0,
 			/**
 			* 改行リサイズの行数
 			*/
@@ -7916,7 +7980,7 @@ void main() {
 			let posY;
 			if (comment.loc === "shita") posY = this.config.canvasHeight - comment.posY - comment.height;
 			else posY = comment.posY;
-			element.textContent = comment.content;
+			this.applyComboContent(element, comment);
 			const lineWidth = getConfig(this.config.contextLineWidth, comment.flash);
 			const strokeColor = getStrokeColor(c, this.config);
 			const strokeWidthPx = lineWidth * drawScale * fontScale * layerScale;
@@ -8410,6 +8474,7 @@ void main() {
 			this.plugins = plugins;
 			this.lazyCommentOrderSortedByVpos = areCommentsSortedByVpos(instances);
 			if (this.ctx.config.fixedCombo) this.fixedComboChains = buildFixedComboChains(instances);
+			if (this.ctx.config.nakaDedupeWindow > 0) applyNakaDedupe(instances, this.ctx.config.nakaDedupeWindow);
 			if (!this.ctx.options.lazy || !this.lazyCommentOrderSortedByVpos) {
 				this.getCommentPos(instances, instances.length);
 				this.sortTimelineComment();

--- a/overlay/lib/niconicomments.min.js
+++ b/overlay/lib/niconicomments.min.js
@@ -2837,6 +2837,11 @@ Released under the MIT License.
 		var _COMBO_COLORS;
 		return (_COMBO_COLORS = COMBO_COLORS[hashText(text) % COMBO_COLORS.length]) !== null && _COMBO_COLORS !== void 0 ? _COMBO_COLORS : "#FFCC00";
 	};
+	/** 每次加载随机抽一个池色(链构建时逐级分配,重放/seek 内稳定) */
+	const pickRandomComboColor = () => {
+		var _COMBO_COLORS$Math$fl;
+		return (_COMBO_COLORS$Math$fl = COMBO_COLORS[Math.floor(Math.random() * COMBO_COLORS.length)]) !== null && _COMBO_COLORS$Math$fl !== void 0 ? _COMBO_COLORS$Math$fl : "#FFCC00";
+	};
 	const isComboCandidate = (comment) => {
 		if (!comment || comment.invisible || comment.owner) return false;
 		if (comment.loc === "naka") return false;
@@ -2852,8 +2857,6 @@ Released under the MIT License.
 		const host = members[0];
 		if (!host) return null;
 		const base = host.content;
-		const originalColor = host.comment.color;
-		const color = pickFixedComboColor(base);
 		const last = members[members.length - 1];
 		if (!last) return null;
 		const end = last.vpos + last.long;
@@ -2869,8 +2872,7 @@ Released under the MIT License.
 		return {
 			host,
 			base,
-			originalColor,
-			color,
+			suffixColor: pickRandomComboColor(),
 			memberVposes: members.map((m) => m.vpos),
 			memberIndices: members.map((m) => m.index),
 			end,
@@ -3537,6 +3539,7 @@ Released under the MIT License.
 		parseContent: () => parseContent,
 		parseFont: () => parseFont,
 		pickFixedComboColor: () => pickFixedComboColor,
+		pickRandomComboColor: () => pickRandomComboColor,
 		processFixedComment: () => processFixedComment,
 		processMovableComment: () => processMovableComment
 	});
@@ -4990,7 +4993,7 @@ Released under the MIT License.
 			const drawScale = getConfig(this.config.commentScale, false) * scale * (this.comment.layer === -1 && !this.comment.owner ? this.ctx.options.scale : 1);
 			const image = this.renderer.getCanvas(HTML5_COMMENT_IMAGE_PADDING);
 			try {
-				var _this$config$fonts$ht2;
+				var _this$config$fonts$ht2, _this$comment$comboSu;
 				image.setSize(this.comment.width, this.getTextImageBounds().height);
 				image.setStrokeStyle(getStrokeColor(this.comment, this.config));
 				image.setFillStyle(this.comment.color);
@@ -5000,8 +5003,15 @@ Released under the MIT License.
 				let lineCount = 0;
 				if (!typeGuard.internal.HTML5Fonts(this.comment.font)) throw new TypeGuardError();
 				const offsetY = (this.comment.charSize - this.comment.lineHeight) / 2 + this.comment.lineHeight * -.16 + (((_this$config$fonts$ht2 = this.config.fonts.html5[this.comment.font]) === null || _this$config$fonts$ht2 === void 0 ? void 0 : _this$config$fonts$ht2.offset) || 0);
-				for (const item of this.comment.content) {
-					if ((item === null || item === void 0 ? void 0 : item.type) === "spacer") {
+				const combo = this.comment.comboSuffix ? {
+					suffix: this.comment.comboSuffix,
+					color: (_this$comment$comboSu = this.comment.comboSuffixColor) !== null && _this$comment$comboSu !== void 0 ? _this$comment$comboSu : this.comment.color
+				} : void 0;
+				const items = this.comment.content;
+				for (let i = 0; i < items.length; i++) {
+					const item = items[i];
+					if (!item) continue;
+					if (item.type === "spacer") {
 						lineCount += item.count * item.charWidth * this.comment.fontSize;
 						continue;
 					}
@@ -5010,8 +5020,20 @@ Released under the MIT License.
 						const line = lines[j];
 						if (line === void 0) continue;
 						const posY = (this.comment.lineHeight * (lineCount + 1 + paddingTop) + offsetY) / scale;
-						image.strokeText(line, 0, posY);
-						image.fillText(line, 0, posY);
+						if (i === items.length - 1 && j === n - 1 && combo && typeof line === "string" && line.endsWith(combo.suffix)) {
+							const base = line.slice(0, -combo.suffix.length);
+							if (base.length > 0) {
+								image.strokeText(base, 0, posY);
+								image.fillText(base, 0, posY);
+							}
+							const baseWidth = image.measureText(base).width;
+							image.setFillStyle(combo.color);
+							image.strokeText(combo.suffix, baseWidth, posY);
+							image.fillText(combo.suffix, baseWidth, posY);
+						} else {
+							image.strokeText(line, 0, posY);
+							image.fillText(line, 0, posY);
+						}
 						lineCount += 1;
 					}
 				}
@@ -7987,16 +8009,42 @@ void main() {
 			element.style.transform = "translateX(-50%)";
 		}
 		/**
+		* 写入弹幕文本:fixedCombo 宿主拆分本体 + 随机色 xN 后缀 span,
+		* 其余弹幕保持整串 textContent。
+		* @param element 目标元素
+		* @param comment 弹幕实例
+		*/
+		applyComboContent(element, comment) {
+			var _c$comboSuffixColor;
+			const c = comment.comment;
+			const suffix = c.comboSuffix;
+			const content = comment.content;
+			if (!suffix) {
+				if (element.textContent !== content) element.textContent = content;
+				return;
+			}
+			if (element.dataset.dmComboSuffix === suffix && element.lastElementChild) return;
+			const base = content.slice(0, -suffix.length);
+			element.replaceChildren();
+			element.appendChild(document.createTextNode(base));
+			const span = document.createElement("span");
+			span.textContent = suffix;
+			span.style.color = (_c$comboSuffixColor = c.comboSuffixColor) !== null && _c$comboSuffixColor !== void 0 ? _c$comboSuffixColor : "inherit";
+			element.appendChild(span);
+			element.dataset.dmComboSuffix = suffix;
+		}
+		/**
 		* fixedCombo 宿主の段階更新を DOM に反映する。
-		* エンジン側(_updateFixedCombo)が comment.content / comment.color を更新済みなので、
-		* ここでテキストと色を同期し、テキスト変化時に pop アニメーションを再生する。
+		* エンジン側(_updateFixedCombo)が comment.content / comboSuffix を更新済みなので、
+		* ここでテキストを同期し、テキスト変化時に pop アニメーションを再生する。
+		* 本体色は原生スタイルを維持し、xN 后缀のみ独立色を持つ。
 		* 要素は固定幅の予約ボックス(中央揃え・テキスト左詰め)のため位置は動かない。
 		*/
 		syncFixedCombo(element, comment) {
 			const c = comment.comment;
 			if (element.textContent !== comment.content) {
 				var _comment$fixedComboZI2;
-				element.textContent = comment.content;
+				this.applyComboContent(element, comment);
 				element.style.color = c.color;
 				element.style.zIndex = String((comment.owner ? 1073741824 : 0) + ((_comment$fixedComboZI2 = comment.fixedComboZIndex) !== null && _comment$fixedComboZI2 !== void 0 ? _comment$fixedComboZI2 : comment.index) + 1);
 				element.style.animation = "";
@@ -8495,7 +8543,8 @@ void main() {
 					host.comment.fontSize = chain.fontSize;
 					host.content = count > 1 ? `${chain.base}x${count}` : chain.base;
 					host.comment.height = chain.height;
-					host.comment.color = count > 1 ? chain.color : chain.originalColor;
+					host.comment.comboSuffix = count > 1 ? `x${count}` : void 0;
+					host.comment.comboSuffixColor = count > 1 ? chain.suffixColor : void 0;
 					host.fixedComboZIndex = (_chain$memberIndices = chain.memberIndices[count - 1]) !== null && _chain$memberIndices !== void 0 ? _chain$memberIndices : host.index;
 				} catch (e) {
 					this._log(`_updateFixedCombo: failed to update host index=${host.index}: ${e instanceof Error ? e.message : String(e)}`);

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -15,6 +15,7 @@ let danmakuTimeOffsetSec = 0;
 let danmakuFontFamily = "";
 let danmakuFontWeight = "";
 let fixedComboEnabled = false; // 固定弹幕渐进合并(= main 的去重开关)
+let nakaDedupeWindow = 0; // 滚动弹幕窗口去重(1/100s,0=关;= main 的去重窗口×100)
 
 let niconiComments = null;
 let nicoRawData = null;
@@ -246,6 +247,7 @@ function initCanvasRenderer(data) {
       commentLimit: commentLimit > 0 ? commentLimit : undefined,
       fonts: buildDanmakuFontConfig(),
       fixedCombo: fixedComboEnabled,
+      nakaDedupeWindow: nakaDedupeWindow,
     },
   });
   nicoRawData = data;
@@ -335,6 +337,7 @@ iina.onMessage("load-danmaku", (data) => {
   if (data.danmakuFontFamily !== undefined) danmakuFontFamily = data.danmakuFontFamily || "";
   if (data.danmakuFontWeight !== undefined) danmakuFontWeight = data.danmakuFontWeight || "";
   if (data.fixedCombo !== undefined) fixedComboEnabled = !!data.fixedCombo;
+  if (data.nakaDedupeWindow !== undefined) nakaDedupeWindow = Number(data.nakaDedupeWindow) || 0;
   if (data.opacity !== undefined) {
     canvasOpacity = data.opacity;
     const canvas = document.getElementById('niconicomments-canvas');
@@ -538,6 +541,7 @@ iina.onMessage("apply-settings", (data) => {
   if (data.danmakuFontFamily !== undefined) danmakuFontFamily = data.danmakuFontFamily || "";
   if (data.danmakuFontWeight !== undefined) danmakuFontWeight = data.danmakuFontWeight || "";
   if (data.fixedCombo !== undefined) fixedComboEnabled = !!data.fixedCombo;
+  if (data.nakaDedupeWindow !== undefined) nakaDedupeWindow = Number(data.nakaDedupeWindow) || 0;
 });
 
 // overlay 自身的 file:// 根目录(插件启动即加载,上报给 main 用于读 opencc.min.js


### PR DESCRIPTION
## Summary

Moves scroll-danmaku (naka) deduplication from the plugin into the rendering engine, and reworks merged-comment styling: the body keeps its native style, only the `xN` suffix gets a random color.

### Engine side (niconicomments, separate repo/PR)

- New config `nakaDedupeWindow` (1/100s, 0 = off): same-text scroll comments within the window are statically merged (earliest wins) — host text becomes `原文xN`, members hidden, owner/fixed/empty-text never participate.
- Merge runs after parsing, before `getCommentPos`, so the merged host width participates in lane assignment.
- CSS renderer now renders the colored suffix span for naka hosts too (`applyComboContent` runs for all comments).

### Plugin side (this PR)

- `getEffectiveContent` no longer pre-merges; the dedupe window is forwarded to the overlay as `nakaDedupeWindow` in every `load-danmaku` payload.
- Removed the render-side merge pipeline: `dedupeNicoJson`, `dedupeContent`, `pickMergeColor`, `MERGE_COLORS`, `encodeXmlText`.
- `mergeDuplicateItems` stays for the sidebar list display merge only.
- Engine bundle updated (cache bump: min.js v12, main.js v13).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable rolling deduplication for overlay comments.
  * Duplicate fixed and scrolling comments are now merged during display.
  * Sidebar entries continue to merge duplicates, showing the combined count with an `xN` suffix.

* **Bug Fixes**
  * Improved consistency between displayed overlay comments and sidebar entries by applying deduplication in the appropriate view.
  * Updated overlay resources to ensure the latest changes load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->