### PR TITLE
fix: resurrected danmaku after clear-danmaku and undefined debugLog in seek handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -2125,7 +2125,7 @@ function registerSidebarHandlers() {
     try {
       core.seekTo(sec); // seekTo 是 core 对象的方法(core.player 不存在)
     } catch (e) {
-      debugLog('danmaku-seek failed: ' + e);
+      console.log('[danmaku-seek] seekTo failed: ' + e);
     }
   });
 

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -517,6 +517,8 @@ iina.onMessage("clear-danmaku", () => {
   if (cssContainer) cssContainer.remove();
   allDanmaku = [];
   nicoRawData = null;
+  rawFormattedData = null;
+  rawNicoJsonData = null;
   nicoRawFormat = 'legacy';
   iina.postMessage("danmaku-type", { type: 'none' });
 });


### PR DESCRIPTION
## Summary
- `clear-danmaku` now also nulls `rawFormattedData` / `rawNicoJsonData` in the overlay. Previously only `nicoRawData` was cleared, so changing scroll speed afterwards rebuilt the renderer from the stale pristine copies — old danmaku reappeared on the new video (repro: load danmaku on video A → switch to a video with no danmaku → drag the scroll-speed slider).
- Replace undefined `debugLog` call in main.js's `danmaku-seek` catch block with `console.log` (`debugLog` only exists in the sidebar context; a `core.seekTo` failure would have thrown a ReferenceError inside the catch handler).

## Test plan
- [ ] Load danmaku on video A, switch to video B without danmaku, drag scroll-speed slider → no danmaku resurrects
- [ ] Normal playback, seek via list timestamp click → unchanged behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized labels identifying cached content older than 24 hours.
  - Older cached results are retained as fallback data and clearly marked as outdated.
  - Fresh results replace outdated cached entries when available.

- **Bug Fixes**
  - Improved fallback behavior when network requests or data conversion fail.
  - Prevented malformed results from being displayed.
  - Clearing danmaku data now fully removes associated raw data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->