### PR TITLE
fix: register time-pos observer on network/manual danmaku load

### DIFF
--- a/main.js
+++ b/main.js
@@ -1962,7 +1962,11 @@ function toggleDanmaku() {
 }
 
 function ensureDanmakuEnabled() {
-  if (danmakuEnabled) return;
+  // 弹幕已开启时也必须确保 time-pos 观察者在位: 会话首个视频若无本地弹幕,
+  // 观察者从未注册,网络/手动路径此时加载弹幕后 overlay 收不到 time-update,
+  // 弹幕按自身墙钟盲跑、seek 失效。setObserver(true) 重复调用安全(先注销
+  // 再注册,并补发一次时间同步,与 loadLocalDanmaku 的既有行为一致)。
+  if (danmakuEnabled) { setObserver(true); return; }
   danmakuEnabled = true;
   preferences.set("danmakuEnabled", true);
   syncPreferencesSoon();


### PR DESCRIPTION
## Problem

With auto-load network danmaku disabled, opening the first video of a session that has no local danmaku files, then loading danmaku via manual network search: after seeking the progress bar, danmaku do not change at all — they keep showing the opening ones and continue on their own timeline. Only a full restart recovers.

Hard to reproduce because any earlier observer-registering event in the same session (a local danmaku load, a toggle cycle, or the pendingDanmaku replay at cold start) masks it — the observer, once registered, persists across videos.

## Root cause

`mpv.time-pos.changed` (the sole source of `time-update` for the overlay) was only registered by:

- local-file loads (`loadLocalDanmaku` → `setObserver(true)`)
- the `pendingDanmaku` replay in `markOverlayReady`
- toggle off→on

All other load paths — DDP auto-match / fresh-cache auto-load / stale-cache fallback (`ddpAddToFileListAndLoad`), the menu manual load, and sidebar file selection — relied solely on `ensureDanmakuEnabled()`, which **early-returns when danmaku is already enabled**, skipping `setObserver(true)`.

So when the first video of a session has no local danmaku (local-first mode, no DDP cache), the observer is never registered. A later manual network load renders danmaku while the overlay never receives a single `time-update`; the overlay free-runs on its own clock (anchor 0 at page load, which coincidentally approximates the video position), and seeks never reach it.

Restart only *appeared* to fix it: the manual load wrote a fresh DDP cache, and at relaunch the cache load usually hits the `pendingDanmaku` path (file-loaded precedes overlay-ready), which does register the observer.

Regression context: before 378a37c, `danmakuNotFound()` force-disabled danmaku, so `ensureDanmakuEnabled()` never early-returned on these paths and the observer got registered implicitly.

## Fix

Call `setObserver(true)` in `ensureDanmakuEnabled()`'s already-enabled branch as well (main.js, 4 new lines + comment). One change covers every affected path:

- manual network search / match selection
- DDP auto-match (auto-network ON)
- fresh-cache auto-load (both modes) — also removes the dependence on the startup race
- stale-cache fallback
- menu "Load Danmaku File…"
- sidebar list selection

`setObserver(true)` is safe to call repeatedly (unregister + re-register, same pattern `loadLocalDanmaku` already produces on every local video). The immediate `time-update` it emits also re-anchors the overlay clock to the real video time at load — even while paused — so any pre-existing clock drift is corrected at load time. The resulting message sequence (`load-danmaku` → `time-update` → `playback-speed` → `resize`) is identical to what local-file loads produce today.

## Testing

- [x] `node --check main.js`
- [x] Traced message ordering and edge cases (paused load, repeated calls, observer already registered)
- [x] Reproduced the original scenario and confirmed seek now follows after manual network load (verified by reporter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playback-time updates for newly loaded or manually added danmaku when danmaku is already enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->