### PR TITLE
refactor: remove dead code and consolidate duplicated load payloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
           zip -r dist/danmaku-cosmos.iinaplgz \
             Info.json \
             main.js \
-            global.js \
             overlay \
             sidebar \
             -x "*.DS_Store" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,6 @@ The CSS renderer (a fork addition, `mode: "css"`) renders text via DOM/CSS inste
 Danmaku Cosmos/
 ├── Info.json                 # Plugin metadata & preference defaults
 ├── main.js                   # Plugin entry: IINA API, file loading, message relay, DDP integration
-├── global.js                 # Global entry (logging only)
 ├── overlay/                  # Danmaku render layer (WebView container)
 │   ├── index.html            # Entry point
 │   ├── index.css             # Render styles
@@ -215,7 +214,6 @@ Later scripts depend on functions mounted on `window` by earlier scripts (e.g., 
   - `_userId` — user ID (number or string)
   - `_dateSec` — Unix timestamp in seconds
   - `_reverse` — whether reverse danmaku (mode 6)
-  - `_layer` — CA layer ID (-1 = default layer, assigned at runtime by niconicomments)
 
 - **Overlay data paths** (`prepareCanvasSource` in `overlay/main.js`):
   - `nico-json` type → `JSON.parse` directly, format detected by `detectNicoFormat` (`v1` when `data[0].comments`, else `legacy`) — pristine copy kept in `rawNicoJsonData`
@@ -246,7 +244,7 @@ Based on the `niconicomments` third-party library. All formats are normalized vi
 ## Coding Conventions
 
 - **Variable declarations**: `var` (main.js/sidebar) and `let` (overlay) are both used. Prefer `let` in new code.
-- **Naming**: camelCase. Private/run-time fields prefix with `_` (e.g., `_layer`, `_commands`)
+- **Naming**: camelCase. Private/run-time fields prefix with `_` (e.g., `_commands`)
 - **Communication**: `iina.postMessage(key, value)` / `iina.onMessage(key, callback)` is the standard pattern. Keep naming consistent.
 - **Danmaku toggle**: Use the shared `toggleDanmaku()` or `ensureDanmakuEnabled()` functions. Do not manually repeat `preferences.set` + `overlay.postMessage` logic.
 - **Network requests**: Use `iina.http` module. DDP API uses `X-AppId`/`X-AppSecret` header auth.

--- a/Info.json
+++ b/Info.json
@@ -7,7 +7,6 @@
     "name": "karappo-yu"
   },
   "entry": "main.js",
-  "globalEntry": "global.js",
   "permissions": [
     "show-osd",
     "video-overlay",

--- a/global.js
+++ b/global.js
@@ -1,2 +1,0 @@
-var console = iina.console;
-console.log("Danmaku Cosmos global entry loaded");

--- a/main.js
+++ b/main.js
@@ -204,8 +204,6 @@ var speedListenerID = null;
 
 var currentDanmakuStatus = {
   fileType: null,
-  fileName: null,
-  relativePath: null,
   isLoaded: false
 };
 
@@ -330,15 +328,12 @@ function findDanmakuFileByPath(path) {
 }
 
 function updateDanmakuStatus(status) {
-  if (status.fileName && typeof status.fileName === 'string') {
-    status.fileName = sanitizeIPCString(status.fileName);
-  }
   currentDanmakuStatus = status;
   sidebarPostMessage("danmaku-type", currentDanmakuStatus);
 }
 
 function danmakuNotFound() {
-  updateDanmakuStatus({ fileType: null, fileName: null, relativePath: null, isLoaded: false });
+  updateDanmakuStatus({ fileType: null, isLoaded: false });
 }
 
 function filePathFromUrl(url) {
@@ -617,22 +612,12 @@ function applyNicoJsonFilters(encodedContent) {
   return encodeContent(JSON.stringify(filteredData));
 }
 
-function applyDanmakuFilter(offset, limit) {
-  danmakuFilterOffset = offset;
-  danmakuFilterLimit = limit;
-  if (!overlayReady) return;
-
-  var ft = currentDanmakuStatus.fileType;
-  if (ft !== 'nico-json') return;
-
-  var selectedPath = danmakuFileList.selectedPaths.length > 0 ? danmakuFileList.selectedPaths[0] : null;
-  if (!selectedPath) return;
-  if (!danmakuCache[selectedPath]) return;
-
-  overlay.postMessage("load-danmaku", {
-    xmlContent: getEffectiveContent(selectedPath),
-    path: selectedPath,
-    danmakuType: 'nico-json',
+// load-danmaku 载荷统一构造。设置字段全量携带: overlay 端逐字段幂等应用,重复携带无副作用。
+function buildLoadDanmakuPayload(xmlContent, path, danmakuType) {
+  return {
+    xmlContent: xmlContent,
+    path: path,
+    danmakuType: danmakuType,
     opacity: canvasOpacity,
     canvasFontScale: canvasFontScale,
     strokeColor: strokeColor,
@@ -647,7 +632,31 @@ function applyDanmakuFilter(offset, limit) {
     preservePosition: true,
     fixedCombo: danmakuDedupeEnabled,
     nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
-  });
+  };
+}
+
+// nico-json 过滤状态整体复位(换视频 / 强制切换 DDP 时)
+function resetNicoJsonFilterState() {
+  nicoJsonTotalCount = 0;
+  clearNicoJsonDuration();
+  danmakuFilterOffset = 0;
+  danmakuFilterLimit = 0;
+  danmakuFilterDensity = 0;
+}
+
+function applyDanmakuFilter(offset, limit) {
+  danmakuFilterOffset = offset;
+  danmakuFilterLimit = limit;
+  if (!overlayReady) return;
+
+  var ft = currentDanmakuStatus.fileType;
+  if (ft !== 'nico-json') return;
+
+  var selectedPath = danmakuFileList.selectedPaths.length > 0 ? danmakuFileList.selectedPaths[0] : null;
+  if (!selectedPath) return;
+  if (!danmakuCache[selectedPath]) return;
+
+  overlay.postMessage("load-danmaku", buildLoadDanmakuPayload(getEffectiveContent(selectedPath), selectedPath, 'nico-json'));
   sendDanmakuFilterInfo();
 }
 
@@ -1078,25 +1087,7 @@ function resendDanmakuToOverlay() {
   if (!overlayReady) return;
   var selectedPath = danmakuFileList.selectedPaths.length > 0 ? danmakuFileList.selectedPaths[0] : null;
   if (!selectedPath || !danmakuCache[selectedPath]) return;
-  overlay.postMessage("load-danmaku", {
-    xmlContent: getEffectiveContent(selectedPath),
-    path: selectedPath,
-    danmakuType: currentDanmakuStatus.fileType,
-    opacity: canvasOpacity,
-    canvasFontScale: canvasFontScale,
-    strokeColor: strokeColor,
-    strokeInversionColor: strokeInversionColor,
-    strokeOpacity: strokeOpacity,
-    strokeWidth: strokeWidth,
-    commentLimit: commentLimit,
-    scrollSpeed: scrollSpeed,
-    danmakuTimeOffsetSec: danmakuTimeOffsetSec,
-    danmakuFontFamily: danmakuFontFamily,
-    danmakuFontWeight: danmakuFontWeight,
-    preservePosition: true,
-    fixedCombo: danmakuDedupeEnabled,
-    nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0
-  });
+  overlay.postMessage("load-danmaku", buildLoadDanmakuPayload(getEffectiveContent(selectedPath), selectedPath, currentDanmakuStatus.fileType));
 }
 
 function extractNumberFromName(name) {
@@ -1364,15 +1355,11 @@ function ensureCacheDir() {
     if (!cacheDir) return null;
     if (!file.exists(cacheDir)) {
       try {
-        if (typeof file.mkdir === 'function') {
-          file.mkdir(cacheDir);
-        } else {
-          var escaped = cacheDir.replace(/'/g, "'\\''");
-          iina.utils.exec('/bin/sh', ['-c', 'mkdir -p ' + "'" + escaped + "'"]);
-        }
-      } catch (e2) {
-        var escaped2 = cacheDir.replace(/'/g, "'\\''");
-        iina.utils.exec('/bin/sh', ['-c', 'mkdir -p ' + "'" + escaped2 + "'"]);
+        if (typeof file.mkdir === 'function') file.mkdir(cacheDir);
+      } catch (e2) {}
+      if (!file.exists(cacheDir)) {
+        var escaped = cacheDir.replace(/'/g, "'\\''");
+        try { iina.utils.exec('/bin/sh', ['-c', 'mkdir -p ' + "'" + escaped + "'"]); } catch (e3) {}
       }
     }
     if (!file.exists(cacheDir)) return null;
@@ -1583,32 +1570,13 @@ function ddpAddToFileListAndLoad(episodeId, animeTitle, episodeTitle, converted,
 
   if (forceLoad) {
     danmakuFileList.selectedPaths = [virtualPath];
-    updateDanmakuStatus({ fileType: 'dandanplay', fileName: displayName, relativePath: 'DanDanPlay #' + episodeId, isLoaded: true });
-    nicoJsonTotalCount = 0;
-    clearNicoJsonDuration();
-    danmakuFilterOffset = 0;
-    danmakuFilterLimit = 0;
-    danmakuFilterDensity = 0;
+    updateDanmakuStatus({ fileType: 'dandanplay', isLoaded: true });
+    resetNicoJsonFilterState();
     sidebarPostMessage("danmaku-file-list", danmakuFileList);
     sendDanmakuFilterInfo();
     notifyBrowserDataChanged();
 
-    var payload = {
-      xmlContent: getEffectiveContent(virtualPath),
-      path: virtualPath,
-      danmakuType: 'dandanplay',
-      opacity: canvasOpacity,
-      canvasFontScale: canvasFontScale,
-      strokeColor: strokeColor,
-      strokeInversionColor: strokeInversionColor,
-      strokeOpacity: strokeOpacity,
-      strokeWidth: strokeWidth,
-      commentLimit: commentLimit,
-      scrollSpeed: scrollSpeed,
-      preservePosition: true,
-      fixedCombo: danmakuDedupeEnabled,
-      nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
-    };
+    var payload = buildLoadDanmakuPayload(getEffectiveContent(virtualPath), virtualPath, 'dandanplay');
     if (overlayReady) {
       overlay.postMessage("load-danmaku", payload);
       loadedDanmakuVideoUrl = currentVideoUrl;
@@ -1730,11 +1698,7 @@ function loadDanmakuForVideo(url) {
   loadedDanmakuVideoUrl = null;
   ddpResetState();
   danmakuNotFound();
-  nicoJsonTotalCount = 0;
-  clearNicoJsonDuration();
-  danmakuFilterOffset = 0;
-  danmakuFilterLimit = 0;
-  danmakuFilterDensity = 0;
+  resetNicoJsonFilterState();
 
   // 视频切换时无条件清掉旧 renderer,即使弹幕当前处于关闭状态。
   if (overlayReady) overlay.postMessage("clear-danmaku", {});
@@ -1845,28 +1809,13 @@ function loadLocalDanmaku(fileInfo) {
   danmakuFilterLimit = 0;
   danmakuFilterDensity = 0;
 
-  updateDanmakuStatus({ fileType: fileType, fileName: fileInfo.filename, relativePath: fileInfo.relativePath, isLoaded: true });
+  updateDanmakuStatus({ fileType: fileType, isLoaded: true });
 
   sidebarPostMessage("danmaku-file-list", danmakuFileList);
   sendDanmakuFilterInfo();
   notifyBrowserDataChanged();
 
-  var payload = {
-    xmlContent: getEffectiveContent(fileInfo.path),
-    path: fileInfo.path,
-    danmakuType: fileType,
-    opacity: canvasOpacity,
-    canvasFontScale: canvasFontScale,
-    strokeColor: strokeColor,
-    strokeInversionColor: strokeInversionColor,
-    strokeOpacity: strokeOpacity,
-    strokeWidth: strokeWidth,
-    commentLimit: commentLimit,
-    scrollSpeed: scrollSpeed,
-    preservePosition: true,
-    fixedCombo: danmakuDedupeEnabled,
-    nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
-  };
+  var payload = buildLoadDanmakuPayload(getEffectiveContent(fileInfo.path), fileInfo.path, fileType);
 
   if (overlayReady) {
     overlay.postMessage("load-danmaku", payload);
@@ -1984,7 +1933,7 @@ function loadManualDanmakuFile(path) {
   danmakuCache[path] = encodedContent; // 必须存缓存: getEffectiveContent 从这里取内容
   var manualFileName = path.split("/").pop();
   var manualFileType = detectDanmakuType(xmlContent);
-  updateDanmakuStatus({ fileType: manualFileType, fileName: manualFileName, relativePath: manualFileName, isLoaded: true });
+  updateDanmakuStatus({ fileType: manualFileType, isLoaded: true });
 
   if (manualFileType === 'nico-json') {
     nicoJsonTotalCount = computeNicoJsonCount(encodedContent);
@@ -1999,22 +1948,7 @@ function loadManualDanmakuFile(path) {
   sendDanmakuFilterInfo();
   notifyBrowserDataChanged();
 
-  var manualPayload = {
-    xmlContent: getEffectiveContent(path),
-    path: path,
-    danmakuType: manualFileType,
-    opacity: canvasOpacity,
-    canvasFontScale: canvasFontScale,
-    strokeColor: strokeColor,
-    strokeInversionColor: strokeInversionColor,
-    strokeOpacity: strokeOpacity,
-    strokeWidth: strokeWidth,
-    commentLimit: commentLimit,
-    scrollSpeed: scrollSpeed,
-    preservePosition: true,
-    fixedCombo: danmakuDedupeEnabled,
-    nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
-  };
+  var manualPayload = buildLoadDanmakuPayload(getEffectiveContent(path), path, manualFileType);
 
   if (overlayReady) {
     overlay.postMessage("load-danmaku", manualPayload);
@@ -2271,8 +2205,6 @@ function registerSidebarHandlers() {
       danmakuForceSimplified: danmakuForceSimplified,
       danmakuAutoOffset: danmakuAutoOffset,
       danmakuFileType: currentDanmakuStatus.fileType,
-      danmakuFileName: currentDanmakuStatus.fileName,
-      danmakuRelativePath: currentDanmakuStatus.relativePath,
       danmakuLoaded: currentDanmakuStatus.isLoaded,
       danmakuFilterDensity: danmakuFilterDensity,
       nicoJsonDurationDiff: nicoJsonDurationDiff,
@@ -2321,7 +2253,6 @@ function registerSidebarHandlers() {
 
     var fileName = filePath.indexOf('dandanplay://') === 0 ? filePath : filePath.split("/").pop();
     var fileInfo = findDanmakuFileByPath(filePath);
-    var relPath = fileInfo ? fileInfo.relativePath : fileName;
     var fileType;
     if (filePath.indexOf('dandanplay://') === 0) {
       fileType = 'dandanplay';
@@ -2330,7 +2261,7 @@ function registerSidebarHandlers() {
       try { decodedForType = decodeURIComponent(encodedContent); } catch (e) { decodedForType = ''; }
       fileType = detectDanmakuType(decodedForType);
     }
-    updateDanmakuStatus({ fileType: fileType, fileName: fileInfo ? fileInfo.filename : fileName, relativePath: relPath, isLoaded: true });
+    updateDanmakuStatus({ fileType: fileType, isLoaded: true });
 
     if (fileType === 'nico-json') {
       nicoJsonTotalCount = computeNicoJsonCount(encodedContent);
@@ -2347,22 +2278,7 @@ function registerSidebarHandlers() {
     sendDanmakuFilterInfo();
     notifyBrowserDataChanged();
 
-    var selectPayload = {
-      xmlContent: getEffectiveContent(filePath),
-      path: filePath,
-      danmakuType: fileType,
-      opacity: canvasOpacity,
-      canvasFontScale: canvasFontScale,
-      strokeColor: strokeColor,
-      strokeInversionColor: strokeInversionColor,
-      strokeOpacity: strokeOpacity,
-      strokeWidth: strokeWidth,
-      commentLimit: commentLimit,
-      scrollSpeed: scrollSpeed,
-      preservePosition: true,
-      fixedCombo: danmakuDedupeEnabled,
-      nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
-    };
+    var selectPayload = buildLoadDanmakuPayload(getEffectiveContent(filePath), filePath, fileType);
 
     overlay.postMessage("load-danmaku", selectPayload);
     loadedDanmakuVideoUrl = currentVideoUrl;

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -1,4 +1,3 @@
-let allDanmaku = [];
 let lastTime = 0;
 let isPaused = false;
 
@@ -82,7 +81,7 @@ function buildFormattedCanvasData(list, sourceType) {
       premium: true,
       mail: Array.isArray(d._commands) ? d._commands : [],
       user_id: toNumericUserId(d._userId, userMap),
-      layer: d._layer === undefined ? -1 : d._layer,
+      layer: -1,
       is_my_post: false
     });
   }
@@ -355,21 +354,21 @@ iina.onMessage("load-danmaku", (data) => {
 
   var danmakuType = data.danmakuType || detectRawDanmakuType(rawStr);
 
+  let parsedList;
   if (danmakuType === 'dandanplay') {
     try {
-      allDanmaku = JSON.parse(rawStr);
+      parsedList = JSON.parse(rawStr);
     } catch (e) {
       console.log('[overlay] parse dandanplay failed: ' + e);
-      allDanmaku = [];
+      parsedList = [];
     }
   } else if (danmakuType === 'nico-json') {
-    allDanmaku = [];
+    parsedList = [];
   } else {
-    allDanmaku = parseDanmaku(rawStr, true);
+    parsedList = parseDanmaku(rawStr, true);
   }
 
-  prepareCanvasSource(rawStr, allDanmaku, danmakuType);
-  allDanmaku = [];
+  prepareCanvasSource(rawStr, parsedList, danmakuType);
 
   iina.postMessage("danmaku-type", { type: danmakuType });
 
@@ -518,7 +517,6 @@ iina.onMessage("clear-danmaku", () => {
   destroyCanvasRenderer();
   const cssContainer = document.querySelector('[data-dm-css-container]');
   if (cssContainer) cssContainer.remove();
-  allDanmaku = [];
   nicoRawData = null;
   rawFormattedData = null;
   rawNicoJsonData = null;

--- a/sidebar/index.js
+++ b/sidebar/index.js
@@ -76,8 +76,6 @@ var state = {
   danmakuForceSimplified: false, // 与 Info.json preferenceDefaults 一致
   danmakuAutoOffset: true,
   danmakuType: 'none',
-  danmakuFileName: null,
-  danmakuRelativePath: null,
   danmakuLoaded: false,
   canvasOpacity: 0.8,
   canvasFontScale: 1.0,
@@ -933,8 +931,6 @@ iina.onMessage("danmaku-state", function (data) {
   if (data.danmakuForceSimplified !== undefined) state.danmakuForceSimplified = !!data.danmakuForceSimplified;
   if (data.danmakuAutoOffset !== undefined) state.danmakuAutoOffset = !!data.danmakuAutoOffset;
   if (data.danmakuFileType !== undefined) state.danmakuType = data.danmakuFileType;
-  if (data.danmakuFileName !== undefined) state.danmakuFileName = data.danmakuFileName;
-  if (data.danmakuRelativePath !== undefined) state.danmakuRelativePath = data.danmakuRelativePath;
   if (data.danmakuLoaded !== undefined) state.danmakuLoaded = data.danmakuLoaded;
   if (data.danmakuFilterDensity !== undefined) state.danmakuFilterDensity = data.danmakuFilterDensity;
   updateUI();
@@ -943,8 +939,6 @@ iina.onMessage("danmaku-state", function (data) {
 
 iina.onMessage("danmaku-type", function (data) {
   if (data.fileType !== undefined) state.danmakuType = data.fileType;
-  if (data.fileName !== undefined) state.danmakuFileName = data.fileName;
-  if (data.relativePath !== undefined) state.danmakuRelativePath = data.relativePath;
   if (data.isLoaded !== undefined) state.danmakuLoaded = data.isLoaded;
   updateUI();
   updateEnabledUI();


### PR DESCRIPTION
## Summary

First-principles cleanup pass: net **-98 lines** (+56/−154). No behavior changes intended; syntax checks and all 5 existing tests pass.

### Deleted (serves no purpose)
- **global.js** — log-only global entry; nothing uses it as a shared scope. Removed the file plus its `globalEntry` wiring in Info.json, release.yml, and AGENTS.md.
- **fileName/relativePath status chain** — sidebar state fields were write-only (never read); removed the fields, their sanitizer, the `danmaku-type` echo payload, and the `request-state` entries. File-list entries' `relativePath` (used for list titles) is kept.
- **overlay `allDanmaku`** — module global only consumed in the tick it was assigned; now a local `parsedList` in the load handler.
- **`_layer` read** — no producer ever sets it; fixed to `-1`.

### Simplified (not optimized)
- 6 near-identical `load-danmaku` payload literals (~17 lines each) → `buildLoadDanmakuPayload()`. Four sites previously omitted font/offset fields; the overlay applies fields idempotently, so carrying them is behavior-neutral.
- 2 verbatim filter-reset blocks → `resetNicoJsonFilterState()` (the 3 conditional partial-reset sites are deliberately left as-is).
- `ensureCacheDir`: collapsed the try/catch whose catch duplicated the else-branch `mkdir -p` fallback into straight-line "mkdir, then exec fallback if still missing".

### Deliberately kept
- Double IPC sanitization (pre-sanitize + `sidebarPostMessage` deep sanitize) — defense in depth around the documented backtick/IPC silent-drop footgun.
- Sidebar `DEBUG_LOG` machinery — documented debug infrastructure.
- Dual i18n dicts and duplicated `decodeXmlText` across main/overlay — separate contexts, not redundancy.

## Test plan
- `node --check` on all changed JS files
- `node --test test/main.video-state.test.js` — 5/5 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Updated plugin packaging to include only the active manifest, main script, overlay, and sidebar components.
  - Removed the obsolete global entry from the plugin configuration.
  - Danmaku status information no longer displays the loaded file name or relative path.
  - Danmaku load results now use consistent payload handling across local, manual, filtered, selected, and DanDanPlay sources.
  - Formatted danmaku layers now consistently use the default layer value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->