### PR TITLE
refactor: 第一性原理审查 — 删除死代码并合并重复设置应用

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,7 +45,6 @@ var stylePreset = preferences.get("stylePreset") || "nico";
 var overlayReady = false;
 var preferencesSyncTimer = null;
 var ddpCacheDirPath = null;
-var ddpCacheDirChecked = false;
 
 var DDP_APP_ID = preferences.get("dandanplayAppId") || 't43832ky57';
 var DDP_APP_SECRET = preferences.get("dandanplayAppSecret") || 'IDnPEdEKDIziKeYVxm6VcaJE4Bv2fnzT';
@@ -210,7 +209,6 @@ var currentDanmakuStatus = {
 var danmakuFileList = {
   xmlFiles: [],
   jsonFiles: [],
-  unknownFiles: [],
   selectedPaths: []
 };
 
@@ -317,7 +315,7 @@ function applyDanmakuFont(fontFamily, fontWeight) {
 }
 
 function findDanmakuFileByPath(path) {
-  var groups = [danmakuFileList.xmlFiles, danmakuFileList.jsonFiles, danmakuFileList.unknownFiles];
+  var groups = [danmakuFileList.xmlFiles, danmakuFileList.jsonFiles];
   for (var g = 0; g < groups.length; g++) {
     var files = groups[g] || [];
     for (var i = 0; i < files.length; i++) {
@@ -629,7 +627,6 @@ function buildLoadDanmakuPayload(xmlContent, path, danmakuType) {
     danmakuTimeOffsetSec: danmakuTimeOffsetSec,
     danmakuFontFamily: danmakuFontFamily,
     danmakuFontWeight: danmakuFontWeight,
-    preservePosition: true,
     fixedCombo: danmakuDedupeEnabled,
     nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0,
   };
@@ -1123,7 +1120,7 @@ function extractDanmakuNumber(filename) {
 
 function findDanmakuByEpisode(videoUrl) {
   var path = filePathFromUrl(videoUrl);
-  if (!path) return { xmlFiles: [], jsonFiles: [], unknownFiles: [] };
+  if (!path) return { xmlFiles: [], jsonFiles: [] };
 
   var videoDir = path.replace(/[/\\][^/\\]+$/, '');
   var videoEpNum = extractEpisodeNumber(path);
@@ -1190,7 +1187,7 @@ function findDanmakuByEpisode(videoUrl) {
 
   var xmlFiles = exactXmlFiles.concat(prefixXmlFiles).concat(epNumXmlFiles);
   var jsonFiles = exactJsonFiles.concat(prefixJsonFiles).concat(epNumJsonFiles);
-  return { xmlFiles: xmlFiles, jsonFiles: jsonFiles, unknownFiles: [] };
+  return { xmlFiles: xmlFiles, jsonFiles: jsonFiles };
 }
 
 function encodeContent(str) {
@@ -1350,7 +1347,7 @@ function ddpConvertComments(ddpComments) {
 
 function ensureCacheDir() {
   try {
-    if (ddpCacheDirChecked && ddpCacheDirPath) return ddpCacheDirPath;
+    if (ddpCacheDirPath) return ddpCacheDirPath;
     var cacheDir = iina.utils.resolvePath('@data/danmaku-cache/');
     if (!cacheDir) return null;
     if (!file.exists(cacheDir)) {
@@ -1369,7 +1366,6 @@ function ensureCacheDir() {
       try { file.delete(oldMap); } catch(e) {}
     }
     ddpCacheDirPath = cacheDir;
-    ddpCacheDirChecked = true;
     return cacheDir;
   } catch (e) {
     return null;
@@ -1706,7 +1702,7 @@ function loadDanmakuForVideo(url) {
   if (core.status.isNetworkResource) {
     core.osd(t('network_skip_local'));
     danmakuNotFound();
-    danmakuFileList = { xmlFiles: [], jsonFiles: [], unknownFiles: [], selectedPaths: [] };
+    danmakuFileList = { xmlFiles: [], jsonFiles: [], selectedPaths: [] };
     sidebarPostMessage("danmaku-file-list", danmakuFileList);
     sendDanmakuFilterInfo();
     notifyBrowserDataChanged();
@@ -1722,7 +1718,6 @@ function loadDanmakuForVideo(url) {
   danmakuFileList = {
     xmlFiles: discovered.xmlFiles,
     jsonFiles: discovered.jsonFiles,
-    unknownFiles: discovered.unknownFiles,
     selectedPaths: []
   };
 
@@ -1845,7 +1840,6 @@ function markOverlayReady() {
     danmakuTimeOffsetSec: danmakuTimeOffsetSec,
     danmakuFontFamily: danmakuFontFamily,
     danmakuFontWeight: danmakuFontWeight,
-    danmakuForceSimplified: danmakuForceSimplified,
     fixedCombo: danmakuDedupeEnabled,
     nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0
   });
@@ -1964,25 +1958,27 @@ function loadManualDanmakuFile(path) {
 function registerSidebarHandlers() {
   sidebar.onMessage("toggle-danmaku", function () { toggleDanmaku(); });
 
-  sidebar.onMessage("set-opacity", function (data) {
-    canvasOpacity = data.opacity;
-    preferences.set("danmakuCanvasOpacity", canvasOpacity);
-    syncPreferencesSoon();
-    overlay.postMessage("set-opacity", { opacity: data.opacity });
-  });
-
-  sidebar.onMessage("set-fontscale", function (data) {
-    canvasFontScale = data.scale;
-    preferences.set("niconicommentsFontScale", canvasFontScale);
-    syncPreferencesSoon();
-    overlay.postMessage("set-fontscale", { scale: data.scale });
-  });
-
-  sidebar.onMessage("set-canvas-mode", function (data) {
-    currentCanvasMode = data.mode;
-    preferences.set("canvasMode", currentCanvasMode);
-    syncPreferencesSoon();
-    overlay.postMessage("set-canvas-mode", { mode: data.mode });
+  // 同构设置处理器: 更新全局变量 → 持久化 → 原样转发给 overlay。
+  // [消息名, 偏好键, 载荷字段, 全局变量赋值]
+  var simpleSettings = [
+    ["set-opacity", "danmakuCanvasOpacity", "opacity", function (v) { canvasOpacity = v; }],
+    ["set-fontscale", "niconicommentsFontScale", "scale", function (v) { canvasFontScale = v; }],
+    ["set-canvas-mode", "canvasMode", "mode", function (v) { currentCanvasMode = v; }],
+    ["set-stroke-opacity", "strokeOpacity", "opacity", function (v) { strokeOpacity = v; }],
+    ["set-stroke-width", "strokeWidth", "width", function (v) { strokeWidth = v; }],
+    ["set-stroke-color", "strokeColor", "color", function (v) { strokeColor = v; }],
+    ["set-stroke-inversion-color", "strokeInversionColor", "color", function (v) { strokeInversionColor = v; }],
+    ["set-comment-limit", "commentLimit", "limit", function (v) { commentLimit = v; }],
+    ["set-scroll-speed", "scrollSpeed", "speed", function (v) { scrollSpeed = v; }]
+  ];
+  simpleSettings.forEach(function (entry) {
+    sidebar.onMessage(entry[0], function (data) {
+      var value = data[entry[2]];
+      entry[3](value);
+      preferences.set(entry[1], value);
+      syncPreferencesSoon();
+      overlay.postMessage(entry[0], data);
+    });
   });
 
   sidebar.onMessage("set-danmaku-force-simplified", function (data) {
@@ -2013,48 +2009,6 @@ function registerSidebarHandlers() {
         checkNicoJsonDuration(danmakuCache[selectedPath]);
       }
     }
-  });
-
-  sidebar.onMessage("set-stroke-opacity", function (data) {
-    strokeOpacity = data.opacity;
-    preferences.set("strokeOpacity", strokeOpacity);
-    syncPreferencesSoon();
-    overlay.postMessage("set-stroke-opacity", { opacity: data.opacity });
-  });
-
-  sidebar.onMessage("set-stroke-width", function (data) {
-    strokeWidth = data.width;
-    preferences.set("strokeWidth", strokeWidth);
-    syncPreferencesSoon();
-    overlay.postMessage("set-stroke-width", { width: data.width });
-  });
-
-  sidebar.onMessage("set-stroke-color", function (data) {
-    strokeColor = data.color;
-    preferences.set("strokeColor", strokeColor);
-    syncPreferencesSoon();
-    overlay.postMessage("set-stroke-color", { color: data.color });
-  });
-
-  sidebar.onMessage("set-stroke-inversion-color", function (data) {
-    strokeInversionColor = data.color;
-    preferences.set("strokeInversionColor", strokeInversionColor);
-    syncPreferencesSoon();
-    overlay.postMessage("set-stroke-inversion-color", { color: data.color });
-  });
-
-  sidebar.onMessage("set-comment-limit", function (data) {
-    commentLimit = data.limit;
-    preferences.set("commentLimit", commentLimit);
-    syncPreferencesSoon();
-    overlay.postMessage("set-comment-limit", { limit: data.limit });
-  });
-
-  sidebar.onMessage("set-scroll-speed", function (data) {
-    scrollSpeed = data.speed;
-    preferences.set("scrollSpeed", scrollSpeed);
-    syncPreferencesSoon();
-    overlay.postMessage("set-scroll-speed", { speed: data.speed });
   });
 
   sidebar.onMessage("set-danmaku-offset", function (data) {
@@ -2179,7 +2133,6 @@ function registerSidebarHandlers() {
       danmakuFileList = {
         xmlFiles: discovered.xmlFiles,
         jsonFiles: discovered.jsonFiles,
-        unknownFiles: discovered.unknownFiles,
         selectedPaths: danmakuFileList.selectedPaths || []
       };
       var cached = ddpReadVideoCache(currentVideoUrl);

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -9,7 +9,7 @@ let strokeInversionColor = '#ffffff';
 let strokeOpacity = 0.4;
 let strokeWidth = 2.8;
 let commentLimit = 0;
-let scrollSpeed = 1.0; // 滚动速度倍率 (0.5 ~ 2.0), 通过 naka 弹幕 long 命令实现
+let scrollSpeed = 1.0; // 滚动速度倍率 (0.25 ~ 1.0), 通过 naka 弹幕 long 命令实现
 let danmakuTimeOffsetSec = 0;
 let danmakuFontFamily = "";
 let danmakuFontWeight = "";
@@ -92,7 +92,6 @@ function prepareCanvasSource(rawStr, parsedList, sourceType) {
   nicoRawData = null;
   rawFormattedData = null;
   rawNicoJsonData = null;
-  nicoRawFormat = 'formatted';
   if (sourceType === 'nico-json') {
     try {
       rawNicoJsonData = JSON.parse(rawStr);
@@ -275,11 +274,6 @@ function initCanvasRenderer(data) {
   }
 }
 
-function destroyCanvasRenderer() {
-  stopCanvasLoop();
-  disposeCanvasRenderer();
-}
-
 function shouldRunCanvasLoop() {
   return !!(niconiComments && danmakuVisible && canvasIsPlaying);
 }
@@ -309,6 +303,32 @@ function stopCanvasLoop() {
   }
 }
 
+// 不透明度同时作用于 canvas(canvas 模式)与 CSS 容器(css 模式)
+function applyOpacityToDom() {
+  const canvas = document.getElementById('niconicomments-canvas');
+  if (canvas && canvasNicoMode !== 'css') canvas.style.opacity = canvasOpacity;
+  const cssContainer = document.querySelector('[data-dm-css-container]');
+  if (cssContainer) cssContainer.style.opacity = canvasOpacity;
+}
+
+// load-danmaku 与 apply-settings 共用的逐字段幂等设置应用(重复携带无副作用)
+function applyOverlaySettings(data) {
+  if (data.opacity !== undefined) { canvasOpacity = data.opacity; applyOpacityToDom(); }
+  if (data.canvasFontScale !== undefined) canvasFontScale = data.canvasFontScale;
+  if (data.canvasMode !== undefined) canvasNicoMode = data.canvasMode;
+  if (data.strokeColor !== undefined) strokeColor = data.strokeColor;
+  if (data.strokeInversionColor !== undefined) strokeInversionColor = data.strokeInversionColor;
+  if (data.strokeOpacity !== undefined) strokeOpacity = data.strokeOpacity;
+  if (data.strokeWidth !== undefined) strokeWidth = data.strokeWidth;
+  if (data.commentLimit !== undefined) commentLimit = data.commentLimit;
+  if (data.scrollSpeed !== undefined) scrollSpeed = data.scrollSpeed;
+  if (data.danmakuTimeOffsetSec !== undefined) danmakuTimeOffsetSec = Number(data.danmakuTimeOffsetSec) || 0;
+  if (data.danmakuFontFamily !== undefined) danmakuFontFamily = data.danmakuFontFamily || "";
+  if (data.danmakuFontWeight !== undefined) danmakuFontWeight = data.danmakuFontWeight || "";
+  if (data.fixedCombo !== undefined) fixedComboEnabled = !!data.fixedCombo;
+  if (data.nakaDedupeWindow !== undefined) nakaDedupeWindow = Number(data.nakaDedupeWindow) || 0;
+}
+
 iina.onMessage("time-update", (data) => {
   let t = data.time * 100;
   const isSeek = Math.abs(t - lastTime) > 150;
@@ -325,25 +345,7 @@ iina.onMessage("time-update", (data) => {
 });
 
 iina.onMessage("load-danmaku", (data) => {
-  if (data.canvasFontScale !== undefined) canvasFontScale = data.canvasFontScale;
-  if (data.strokeOpacity !== undefined) strokeOpacity = data.strokeOpacity;
-  if (data.strokeWidth !== undefined) strokeWidth = data.strokeWidth;
-  if (data.strokeColor !== undefined) strokeColor = data.strokeColor;
-  if (data.strokeInversionColor !== undefined) strokeInversionColor = data.strokeInversionColor;
-  if (data.commentLimit !== undefined) commentLimit = data.commentLimit;
-  if (data.scrollSpeed !== undefined) scrollSpeed = data.scrollSpeed;
-  if (data.danmakuTimeOffsetSec !== undefined) danmakuTimeOffsetSec = Number(data.danmakuTimeOffsetSec) || 0;
-  if (data.danmakuFontFamily !== undefined) danmakuFontFamily = data.danmakuFontFamily || "";
-  if (data.danmakuFontWeight !== undefined) danmakuFontWeight = data.danmakuFontWeight || "";
-  if (data.fixedCombo !== undefined) fixedComboEnabled = !!data.fixedCombo;
-  if (data.nakaDedupeWindow !== undefined) nakaDedupeWindow = Number(data.nakaDedupeWindow) || 0;
-  if (data.opacity !== undefined) {
-    canvasOpacity = data.opacity;
-    const canvas = document.getElementById('niconicomments-canvas');
-    if (canvas && canvasNicoMode !== 'css') canvas.style.opacity = data.opacity;
-    const cssContainer = document.querySelector('[data-dm-css-container]');
-    if (cssContainer) cssContainer.style.opacity = data.opacity;
-  }
+  applyOverlaySettings(data);
 
   const encodedStr = data.xmlContent;
   let rawStr;
@@ -374,9 +376,6 @@ iina.onMessage("load-danmaku", (data) => {
 
   if (nicoRawData) {
     canvasIsPlaying = !isPaused;
-    if (!data.preservePosition) {
-      canvasSyncAnchor(0);
-    }
     initCanvasRenderer(nicoRawData);
     startCanvasLoop();
   }
@@ -437,10 +436,7 @@ iina.onMessage("toggle-danmaku", (data) => {
 
 iina.onMessage("set-opacity", (data) => {
   canvasOpacity = data.opacity;
-  const canvas = document.getElementById('niconicomments-canvas');
-  if (canvas && canvasNicoMode !== 'css') canvas.style.opacity = data.opacity;
-  const cssContainer = document.querySelector('[data-dm-css-container]');
-  if (cssContainer) cssContainer.style.opacity = data.opacity;
+  applyOpacityToDom();
 });
 
 iina.onMessage("set-fontscale", (data) => {
@@ -514,7 +510,8 @@ iina.onMessage("set-danmaku-font", (data) => {
 });
 
 iina.onMessage("clear-danmaku", () => {
-  destroyCanvasRenderer();
+  stopCanvasLoop();
+  disposeCanvasRenderer();
   const cssContainer = document.querySelector('[data-dm-css-container]');
   if (cssContainer) cssContainer.remove();
   nicoRawData = null;
@@ -525,26 +522,7 @@ iina.onMessage("clear-danmaku", () => {
 });
 
 iina.onMessage("apply-settings", (data) => {
-  if (data.opacity !== undefined) {
-    canvasOpacity = data.opacity;
-    const canvas = document.getElementById('niconicomments-canvas');
-    if (canvas && canvasNicoMode !== 'css') canvas.style.opacity = data.opacity;
-    const cssContainer = document.querySelector('[data-dm-css-container]');
-    if (cssContainer) cssContainer.style.opacity = data.opacity;
-  }
-  if (data.canvasFontScale !== undefined) canvasFontScale = data.canvasFontScale;
-  if (data.canvasMode !== undefined) canvasNicoMode = data.canvasMode;
-  if (data.strokeColor !== undefined) strokeColor = data.strokeColor;
-  if (data.strokeInversionColor !== undefined) strokeInversionColor = data.strokeInversionColor;
-  if (data.strokeOpacity !== undefined) strokeOpacity = data.strokeOpacity;
-  if (data.strokeWidth !== undefined) strokeWidth = data.strokeWidth;
-  if (data.commentLimit !== undefined) commentLimit = data.commentLimit;
-  if (data.scrollSpeed !== undefined) scrollSpeed = data.scrollSpeed;
-  if (data.danmakuTimeOffsetSec !== undefined) danmakuTimeOffsetSec = Number(data.danmakuTimeOffsetSec) || 0;
-  if (data.danmakuFontFamily !== undefined) danmakuFontFamily = data.danmakuFontFamily || "";
-  if (data.danmakuFontWeight !== undefined) danmakuFontWeight = data.danmakuFontWeight || "";
-  if (data.fixedCombo !== undefined) fixedComboEnabled = !!data.fixedCombo;
-  if (data.nakaDedupeWindow !== undefined) nakaDedupeWindow = Number(data.nakaDedupeWindow) || 0;
+  applyOverlaySettings(data);
 });
 
 // overlay 自身的 file:// 根目录(插件启动即加载,上报给 main 用于读 opencc.min.js


### PR DESCRIPTION
## 概述

从第一性原理审视现有代码后的清理：**净减 69 行**（+58/−127），无行为变化，`node --test` 5/5 通过，`node --check` 全部通过。

大部分复杂结构（`getEffectiveContent` 单源出口、base64 分块投递、IPC 消毒、世代号、pristine 副本 + 速度注入）均为 IINA IPC 真实约束的直接应答，审查后确认保留。

## 删除（死代码）

- **`unknownFiles`** — `findDanmakuByEpisode` 从不填充，sidebar 从不读取，7 处引用全是搬运空数组
- **`preservePosition`** — `load-danmaku` 载荷恒为 `true`,overlay 的 `canvasSyncAnchor(0)` 分支从不执行
- **`ddpCacheDirChecked`** — 只与 `ddpCacheDirPath` 同时赋值，判空完全等价
- **`apply-settings` 载荷中的 `danmakuForceSimplified`** — overlay 处理器从不读取（转换在 main 侧完成）
- **`destroyCanvasRenderer`** — 单处调用的别名，内联进 `clear-danmaku`

## 简化（删除之后）

- **overlay**: 三处重复的逐字段设置应用合并为 `applyOverlaySettings()`（`load-danmaku` / `apply-settings` 共用）+ `applyOpacityToDom()`（`set-opacity` 共用）
- **main.js**: 8 个同构的 sidebar 设置处理器（persist + sync + forward）折叠为表驱动注册器
- 消除 `prepareCanvasSource` 中 `nicoRawFormat` 的重复赋值
- 修正过期的 scrollSpeed 范围注释（0.5~2.0 → 0.25~1.0）

## 明确不动的

Canvas 渲染模式（有意的 fallback)、DDP 过期缓存回退（断网场景）、A/D 键偏移（既有设计）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved danmaku loading so the current playback position is preserved when loading or refreshing comments.
  * Made overlay settings apply consistently across loading and settings updates.
  * Improved opacity handling for the comment display and its surrounding canvas.

* **Refactor**
  * Streamlined sidebar setting updates without changing the available settings or controls.
  * Simplified danmaku file and cache handling for more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->