### PR TITLE
refactor: simplify danmaku message and state flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ Three data paths in `overlay/main.js`:
 
 ### Time Offset
 
-`set-danmaku-offset` → `applyDanmakuOffset()` (persist + forward). Overlay adds `danmakuTimeOffsetSec` inside `canvasGetCurrentTime()` (base time + offset), so both CSS and Canvas modes shift instantly. Sidebar: number input (±30s, step 0.5) and A/D keys (only when sidebar has focus; step = |current offset|, fallback 1 — quirky but works); both send `set-danmaku-offset`.
+`set-danmaku-offset` → `applyDanmakuOffset()` (session-only; not persisted). The offset resets to zero on each video load, then forwards to overlay and sidebar. Overlay adds `danmakuTimeOffsetSec` inside `canvasGetCurrentTime()` (base time + offset), so both CSS and Canvas modes shift instantly. Sidebar: number input (±30s, step 0.5) and A/D keys (only when sidebar has focus; step = |current offset|, fallback 1 — quirky but works); both send `set-danmaku-offset`.
 
 ### Danmaku Deduplication (engine-side render merge, plugin-side list merge)
 
@@ -177,7 +177,7 @@ All communication uses `postMessage` / `onMessage` across three channels:
 |---------|-----------|---------|
 | `main.js ↔ overlay` | Bidirectional | Danmaku data, time updates, render params, mode switching |
 | `main.js ↔ sidebar` | Bidirectional | Sidebar UI state sync, operation commands |
-| `overlay → main.js` | One-way | Canvas unsupported notice, jump commands, seek state |
+| `overlay → main.js` | One-way | Jump commands, seek state |
 | `sidebar → main.js` | One-way | Toggle, param changes, file operations |
 
 Customization messages (sidebar → main.js → overlay): `set-fontscale`, `set-stroke-width`, `set-stroke-opacity`, `set-stroke-color`, `set-stroke-inversion-color`, `set-comment-limit`, `set-scroll-speed` (multiplier 0.25–1.0), `set-danmaku-offset`, `set-danmaku-font`, `set-style-preset` (persisted in main.js only, not forwarded).
@@ -200,7 +200,7 @@ Customization messages (sidebar → main.js → overlay): `set-fontscale`, `set-
 niconicomments.min.js → input.js → main.js
 ```
 
-`lib/opencc.min.js` (1.1MB) is intentionally NOT in this load order — it is injected dynamically by `ensureOpenCCLoaded()` in `overlay/main.js` the first time 强制简体 is enabled. When the bundle becomes ready while danmaku is already on screen, `rebuildFromLastLoad()` re-parses `lastLoadRawStr` so conversion takes effect immediately. Do not add it back to `index.html` — the goal is keeping overlay startup free of the 1.1MB parse cost.
+`main.js` uses `ensureBrowserSimplifier()` to read and evaluate the local OpenCC bundle only when conversion is needed; the converted content is applied before sending `load-danmaku`.
 
 Later scripts depend on functions mounted on `window` by earlier scripts (e.g., `window.parseDanmaku` from `input.js`). Do not reorder the `<script>` tags.
 
@@ -213,7 +213,6 @@ Later scripts depend on functions mounted on `window` by earlier scripts (e.g., 
   - `_commands` — array of mail commands (e.g., `['naka', '#ffffff', 'big']`)
   - `_userId` — user ID (number or string)
   - `_dateSec` — Unix timestamp in seconds
-  - `_reverse` — whether reverse danmaku (mode 6)
 
 - **Overlay data paths** (`prepareCanvasSource` in `overlay/main.js`):
   - `nico-json` type → `JSON.parse` directly, format detected by `detectNicoFormat` (`v1` when `data[0].comments`, else `legacy`) — pristine copy kept in `rawNicoJsonData`
@@ -265,7 +264,7 @@ Based on the `niconicomments` third-party library. All formats are normalized vi
 
 - `canvas.width = 1920; canvas.height = 1080` is hardcoded and does not adapt to window aspect ratio
 - Filenames containing `[` or `]` may cause auto-load to fail (regex matching in `extractNumberFromName`, `[n]`-style only; special formats like `第3话` often fail)
-- Canvas mode does not support CSS-mode-specific settings (font scale, scroll duration, blocking, lane limits)
+- Canvas mode receives the same filtered source content as CSS mode, but does not support CSS-specific animation/layout behavior.
 - CSS mode (niconicomments) Comment Art vertical positioning may differ slightly from Canvas mode
 - DDP cache only stores the last loaded episode per video (hash overwrite)
 - Backtick U+0060 in any sidebar message field causes IINA IPC to silently drop the entire message

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ Dedup is split across two sides with the SAME window semantics (greedy from earl
 | Setting | Behavior |
 |---------|----------|
 | **ON** (`dandanplayAutoNetwork=true`) | Network-first: fresh DDP cache auto-loads without any network traffic; no cache → auto-match |
-| **OFF** (`dandanplayAutoNetwork=false`) | Local-first: load local files, DDP cache shown in list but not auto-loaded |
+| **OFF** (`dandanplayAutoNetwork=false`) | Local-first: load local files; no local files → fall back to auto-loading a fresh DDP cache (stale cache is listed but never auto-loaded) |
 
 ### DDP Comment Conversion
 

--- a/Info.json
+++ b/Info.json
@@ -2,7 +2,7 @@
   "name": "Danmaku Cosmos",
   "identifier": "com.danmaku-cosmos.iina-plugin",
   "version": "4.5",
-  "description": "IINA弹幕插件 (niconicocomments-only渲染)",
+  "description": "IINA danmaku plugin with local files, Dandanplay network matching, and CSS/Canvas rendering",
   "author": {
     "name": "karappo-yu"
   },

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ CA 弹幕：
 - **自动匹配**：优先根据文件 hash 精确匹配（自动加载），失败后根据视频文件名匹配（显示候选列表供选择）
 - **手动搜索**：上述匹配均失败时，可手动搜索番剧名称，从搜索结果中选择
 - **弹幕缓存**：网络弹幕缓存到本地，24 小时内重复播放无需重新下载
-- **自动加载开关**：开启后自动匹配并加载网络弹幕；关闭时优先使用本地弹幕，网络弹幕仅在手动选择时加载
-- **弹幕冲突处理**：网络弹幕和本地弹幕同时存在时，根据优先级自动选择
+- **自动加载开关**：开启（`dandanplayAutoNetwork=true`）时采用网络优先：新鲜缓存立即加载，否则自动匹配；关闭时采用本地优先，仅在没有本地弹幕时使用新鲜的弹弹play缓存
+- **弹幕冲突处理**：由上述自动加载开关决定网络优先或本地优先
 
 > **注意**：弹弹play 提供的网络弹幕内容以简体中文和繁体中文为主，不包含其他语言。若习惯阅读简体，可开启“强制繁转简”选项。
 
@@ -187,8 +187,8 @@ CA 弹幕：
 - **自動マッチング**：ファイルハッシュによる完全一致（自動読み込み）→ ファイル名による曖昧一致（候補一覧表示）の順で試行
 - **手動検索**：上記が全て失敗した場合、番組名を手動検索可能
 - **キャッシュ**：ネットワークコメントはローカルにキャッシュされ、24時間以内の再再生では再ダウンロード不要
-- **自動読み込みトグル**：ON で自動マッチング＋自動読み込み、OFF では優先的にローカルコメントを使用
-- **競合処理**：ネットワークコメントとローカルコメントが共存する場合、優先設定に従って自動選択
+- **自動読み込みトグル**：ON（`dandanplayAutoNetwork=true`）ではネットワーク優先（新鮮なキャッシュを即時ロードし、なければ自動マッチング）、OFF ではローカル優先で、ローカルコメントがない場合のみ新鮮な弹弹play キャッシュを使用
+- **競合処理**：上記の自動読み込みトグルによりネットワーク優先／ローカル優先を切り替え
 
 > **注意**：弹弹play から提供されるネットワークコメントは簡体字中国語・繁体字中国語が主体で、他の言語は含まれません。
 
@@ -262,8 +262,7 @@ The plugin integrates the dandanplay open platform API for automatic network dan
 - **Auto-match**: First tries file hash (auto-load on exact match), then falls back to filename matching (shows candidate list)
 - **Manual search**: Search by anime name when both matching methods fail
 - **Cache**: Network danmaku is cached locally; replay within 24 hours skips re-download
-- **Auto-load toggle**: ON for automatic network matching + loading; OFF prefers local files
-- **Conflict resolution**: When both local and network danmaku exist, priority setting determines which to use
+- **Auto-load toggle**: ON (`dandanplayAutoNetwork=true`) uses network-first behavior (fresh cache loads immediately; otherwise auto-match); OFF uses local-first behavior and only falls back to a fresh Dandanplay cache
 
 > **Note**: Network danmaku provided by Dandanplay is predominantly Simplified Chinese and Traditional Chinese — other languages are not available.
 
@@ -324,7 +323,7 @@ The MIT License requires that the copyright notice and license text be included 
 
 The niconicomments author notes that implementing the complete flow of "real-time comment fetching → screen rendering → comment posting" may involve Japanese patents. See [ABOUT_PATENT.md](https://github.com/xpadev-net/niconicomments/blob/develop/ABOUT_PATENT.md) for details.
 
-This plugin is used solely for local playback of saved comment files and does not involve real-time fetching or posting functionality.
+This plugin supports local playback of saved danmaku files and also retrieves danmaku from the Dandanplay API when its network matching feature is enabled. It does not implement real-time comment posting.
 
 ---
 

--- a/main.js
+++ b/main.js
@@ -611,11 +611,11 @@ function applyNicoJsonFilters(encodedContent) {
 }
 
 // load-danmaku 载荷统一构造。设置字段全量携带: overlay 端逐字段幂等应用,重复携带无副作用。
-function buildLoadDanmakuPayload(xmlContent, path, danmakuType) {
+function buildLoadDanmakuPayload(xmlContent, danmakuType) {
   return {
     xmlContent: xmlContent,
-    path: path,
     danmakuType: danmakuType,
+    canvasMode: currentCanvasMode,
     opacity: canvasOpacity,
     canvasFontScale: canvasFontScale,
     strokeColor: strokeColor,
@@ -653,7 +653,7 @@ function applyDanmakuFilter(offset, limit) {
   if (!selectedPath) return;
   if (!danmakuCache[selectedPath]) return;
 
-  overlay.postMessage("load-danmaku", buildLoadDanmakuPayload(getEffectiveContent(selectedPath), selectedPath, 'nico-json'));
+  overlay.postMessage("load-danmaku", buildLoadDanmakuPayload(getEffectiveContent(selectedPath), 'nico-json'));
   sendDanmakuFilterInfo();
 }
 
@@ -1084,7 +1084,7 @@ function resendDanmakuToOverlay() {
   if (!overlayReady) return;
   var selectedPath = danmakuFileList.selectedPaths.length > 0 ? danmakuFileList.selectedPaths[0] : null;
   if (!selectedPath || !danmakuCache[selectedPath]) return;
-  overlay.postMessage("load-danmaku", buildLoadDanmakuPayload(getEffectiveContent(selectedPath), selectedPath, currentDanmakuStatus.fileType));
+  overlay.postMessage("load-danmaku", buildLoadDanmakuPayload(getEffectiveContent(selectedPath), currentDanmakuStatus.fileType));
 }
 
 function extractNumberFromName(name) {
@@ -1572,7 +1572,7 @@ function ddpAddToFileListAndLoad(episodeId, animeTitle, episodeTitle, converted,
     sendDanmakuFilterInfo();
     notifyBrowserDataChanged();
 
-    var payload = buildLoadDanmakuPayload(getEffectiveContent(virtualPath), virtualPath, 'dandanplay');
+    var payload = buildLoadDanmakuPayload(getEffectiveContent(virtualPath), 'dandanplay');
     if (overlayReady) {
       overlay.postMessage("load-danmaku", payload);
       loadedDanmakuVideoUrl = currentVideoUrl;
@@ -1793,16 +1793,11 @@ function loadLocalDanmaku(fileInfo) {
   var encodedContent = encodeContent(contentToSend);
   danmakuCache[fileInfo.path] = encodedContent;
 
+  resetNicoJsonFilterState();
   if (fileType === 'nico-json') {
     nicoJsonTotalCount = computeNicoJsonCount(encodedContent);
     checkNicoJsonDuration(encodedContent);
-  } else {
-    nicoJsonTotalCount = 0;
-    clearNicoJsonDuration();
   }
-  danmakuFilterOffset = 0;
-  danmakuFilterLimit = 0;
-  danmakuFilterDensity = 0;
 
   updateDanmakuStatus({ fileType: fileType, isLoaded: true });
 
@@ -1810,7 +1805,7 @@ function loadLocalDanmaku(fileInfo) {
   sendDanmakuFilterInfo();
   notifyBrowserDataChanged();
 
-  var payload = buildLoadDanmakuPayload(getEffectiveContent(fileInfo.path), fileInfo.path, fileType);
+  var payload = buildLoadDanmakuPayload(getEffectiveContent(fileInfo.path), fileType);
 
   if (overlayReady) {
     overlay.postMessage("load-danmaku", payload);
@@ -1827,22 +1822,6 @@ function markOverlayReady() {
   if (overlayReady) return;
   overlayReady = true;
   overlay.show();
-  overlay.postMessage("apply-settings", {
-    opacity: canvasOpacity,
-    canvasFontScale: canvasFontScale,
-    canvasMode: currentCanvasMode,
-    strokeColor: strokeColor,
-    strokeInversionColor: strokeInversionColor,
-    strokeOpacity: strokeOpacity,
-    strokeWidth: strokeWidth,
-    commentLimit: commentLimit,
-    scrollSpeed: scrollSpeed,
-    danmakuTimeOffsetSec: danmakuTimeOffsetSec,
-    danmakuFontFamily: danmakuFontFamily,
-    danmakuFontWeight: danmakuFontWeight,
-    fixedCombo: danmakuDedupeEnabled,
-    nakaDedupeWindow: danmakuDedupeEnabled ? danmakuDedupeWindow * 100 : 0
-  });
 
   if (pendingDanmaku) {
     overlay.postMessage("load-danmaku", pendingDanmaku);
@@ -1929,20 +1908,15 @@ function loadManualDanmakuFile(path) {
   var manualFileType = detectDanmakuType(xmlContent);
   updateDanmakuStatus({ fileType: manualFileType, isLoaded: true });
 
+  resetNicoJsonFilterState();
   if (manualFileType === 'nico-json') {
     nicoJsonTotalCount = computeNicoJsonCount(encodedContent);
     checkNicoJsonDuration(encodedContent);
-  } else {
-    nicoJsonTotalCount = 0;
-    clearNicoJsonDuration();
   }
-  danmakuFilterOffset = 0;
-  danmakuFilterLimit = 0;
-  danmakuFilterDensity = 0;
   sendDanmakuFilterInfo();
   notifyBrowserDataChanged();
 
-  var manualPayload = buildLoadDanmakuPayload(getEffectiveContent(path), path, manualFileType);
+  var manualPayload = buildLoadDanmakuPayload(getEffectiveContent(path), manualFileType);
 
   if (overlayReady) {
     overlay.postMessage("load-danmaku", manualPayload);
@@ -2216,22 +2190,17 @@ function registerSidebarHandlers() {
     }
     updateDanmakuStatus({ fileType: fileType, isLoaded: true });
 
+    resetNicoJsonFilterState();
     if (fileType === 'nico-json') {
       nicoJsonTotalCount = computeNicoJsonCount(encodedContent);
       checkNicoJsonDuration(encodedContent);
-    } else {
-      nicoJsonTotalCount = 0;
-      clearNicoJsonDuration();
     }
-    danmakuFilterOffset = 0;
-    danmakuFilterLimit = 0;
-    danmakuFilterDensity = 0;
 
     sidebarPostMessage("danmaku-file-list", danmakuFileList);
     sendDanmakuFilterInfo();
     notifyBrowserDataChanged();
 
-    var selectPayload = buildLoadDanmakuPayload(getEffectiveContent(filePath), filePath, fileType);
+    var selectPayload = buildLoadDanmakuPayload(getEffectiveContent(filePath), fileType);
 
     overlay.postMessage("load-danmaku", selectPayload);
     loadedDanmakuVideoUrl = currentVideoUrl;

--- a/overlay/main.js
+++ b/overlay/main.js
@@ -46,14 +46,6 @@ function detectNicoFormat(data) {
   return 'legacy';
 }
 
-function detectRawDanmakuType(rawStr) {
-  const s = rawStr ? rawStr.trim() : '';
-  if (!s) return 'bilibili-xml';
-  if (s.charAt(0) === '[') return 'nico-json';
-  if (s.indexOf('<packet') !== -1) return 'nico-xml';
-  return 'bilibili-xml';
-}
-
 function toNumericUserId(userId, userMap) {
   const numeric = Number(userId);
   if (!isNaN(numeric) && isFinite(numeric)) return numeric;
@@ -311,7 +303,7 @@ function applyOpacityToDom() {
   if (cssContainer) cssContainer.style.opacity = canvasOpacity;
 }
 
-// load-danmaku 与 apply-settings 共用的逐字段幂等设置应用(重复携带无副作用)
+// load-danmaku 共用的逐字段幂等设置应用(重复携带无副作用)
 function applyOverlaySettings(data) {
   if (data.opacity !== undefined) { canvasOpacity = data.opacity; applyOpacityToDom(); }
   if (data.canvasFontScale !== undefined) canvasFontScale = data.canvasFontScale;
@@ -354,7 +346,7 @@ iina.onMessage("load-danmaku", (data) => {
     return;
   }
 
-  var danmakuType = data.danmakuType || detectRawDanmakuType(rawStr);
+  var danmakuType = data.danmakuType;
 
   let parsedList;
   if (danmakuType === 'dandanplay') {
@@ -512,6 +504,10 @@ iina.onMessage("set-danmaku-font", (data) => {
 iina.onMessage("clear-danmaku", () => {
   stopCanvasLoop();
   disposeCanvasRenderer();
+  lastTime = 0;
+  canvasVideoAnchorTime = 0;
+  canvasSystemAnchorTime = 0;
+  canvasIsPlaying = false;
   const cssContainer = document.querySelector('[data-dm-css-container]');
   if (cssContainer) cssContainer.remove();
   nicoRawData = null;
@@ -519,10 +515,6 @@ iina.onMessage("clear-danmaku", () => {
   rawNicoJsonData = null;
   nicoRawFormat = 'legacy';
   iina.postMessage("danmaku-type", { type: 'none' });
-});
-
-iina.onMessage("apply-settings", (data) => {
-  applyOverlaySettings(data);
 });
 
 // overlay 自身的 file:// 根目录(插件启动即加载,上报给 main 用于读 opencc.min.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "description": "No build tools — this file is a stub only. @xmldom/xmldom is not used.",
+  "description": "No build step; package.json provides the Node test command for the vanilla IINA plugin.",
   "scripts": {
     "test": "node --test test/*.test.js"
   }

--- a/sidebar/index.css
+++ b/sidebar/index.css
@@ -592,19 +592,10 @@ input[type="color"]::-webkit-color-swatch {
   color: var(--label);
 }
 
-/* ========== Advanced collapsible ========== */
-#advanced-toggle,
+/* ========== Dandanplay search results ========== */
 #dandanplay-search-results-toggle {
   cursor: pointer;
   user-select: none;
-}
-
-#advanced-toggle:hover .section-title {
-  color: var(--label);
-}
-
-#advanced-content {
-  padding-top: 4px;
 }
 
 /* ========== Misc ========== */

--- a/sidebar/index.js
+++ b/sidebar/index.js
@@ -1248,7 +1248,6 @@ iina.onMessage("dandanplay-bangumi-result", function (data) {
    数据由 sidebar 主动向 main.js 拉取(danmaku-browser-request,懒加载约束);
    main 侧按与 overlay 相同的过滤(切片/密度/强制简体)构建,保证列表与渲染一致。 */
 var BROWSER_ROW_H = 26;
-var browserItems = [];         // [{t, text, blocked, merged}] 按 t 升序(全量,接收原样)
 var browserVpos = -1;          // 最近一次时间消息的 vpos(1/100s)
 var browserFollowLive = true;  // 跟随模式: 锚定 vpos 行滚动(用户手动翻阅时退出)
 var browserRenderedSourceKey = ''; // 上次渲染完成时的弹幕源标识(fileListState.selectedPaths[0])
@@ -1388,7 +1387,7 @@ function browserUpdateTotal() {
 function browserUpdateLiveUI() {
   // 播放时间显示已移除(标题行不再展示);只维护"回到实时"按钮
   var btn = document.getElementById("danmaku-browser-follow-btn");
-  if (btn) btn.style.display = (browserFollowLive || browserItems.length === 0) ? "none" : "";
+  if (btn) btn.style.display = (browserFollowLive || browserList.items.length === 0) ? "none" : "";
 }
 
 // 聊天栏式跟随: 锚定 vpos 对应行并保持其在可视区底部,新弹幕到点在底部"推出"
@@ -1471,10 +1470,9 @@ iina.onMessage("danmaku-browser-data", function (data) {
   var isDone = data.done !== false;
   if (chunkIndex === 0) {
     // 新数据或重发: 重置状态
-    browserItems = [];
+    browserList.items = [];
     browserVpos = -1;
     browserNextChunk = 1;
-    browserList.items = [];
     browserList.rowNodes.forEach(function (el) { el.remove(); });
     browserList.rowNodes.clear();
     // 弹幕源切换标记: 当前选中的弹幕文件(danmaku-file-list 消息维护)与
@@ -1494,20 +1492,15 @@ iina.onMessage("danmaku-browser-data", function (data) {
   for (var i = 0; i < items.length; i++) {
     var item = items[i];
     if (!item || typeof item.t !== 'number' || !isFinite(item.t) || !item.text) continue;
-    browserItems.push({ t: item.t, text: item.text, blocked: !!item.blocked, merged: !!item.merged, owner: !!item._owner });
+    browserList.items.push({ t: item.t, text: item.text, blocked: !!item.blocked, merged: !!item.merged, owner: !!item._owner });
   }
   if (!isDone) {
     // 传输中不渲染(done 时一次性渲染)
     return;
   }
+  debugLog('danmaku-browser: data complete, total=' + browserList.items.length + ', chunks=' + (chunkIndex + 1));
   // 全部收齐: 单容器渲染
-  debugLog('danmaku-browser: data complete, total=' + browserItems.length + ', chunks=' + (chunkIndex + 1));
-  browserList.items = browserItems;
-  // 渲染前把 scrollTop 规整到新列表合法范围并标记为程序滚动目标:
-  // 恢复动作不一定锚定(播放位置未推送时跳过),此时滚动位置可能超出
-  // 新列表范围,浏览器渲染时的收紧事件会被误判为手动翻阅;主动规整
-  // 后收紧事件命中程序分支,不退出实时
-  var maxScroll = Math.max(0, browserItems.length * BROWSER_ROW_H - browserList.el.clientHeight);
+  var maxScroll = Math.max(0, browserList.items.length * BROWSER_ROW_H - browserList.el.clientHeight);
   if (browserList.el.scrollTop > maxScroll) {
     browserProgramScrollTop = maxScroll;
     browserList.el.scrollTop = maxScroll;
@@ -1533,7 +1526,7 @@ iina.onMessage("danmaku-visible-time", function (data) {
   var vpos = Math.round((data.time + (data.offset || 0)) * 100);
   browserVpos = vpos;
   // 自愈: 时间信号在流动但本地无列表数据 → 重新拉取
-  if (browserItems.length === 0) requestBrowserDataRefresh();
+  if (browserList.items.length === 0) requestBrowserDataRefresh();
   browserUpdateLiveUI();
   if (browserFollowLive) browserFollowToLive();
 });

--- a/test/main.video-state.test.js
+++ b/test/main.video-state.test.js
@@ -134,17 +134,17 @@ function createHarness(initialEnabled, autoNetwork = false) {
   };
 }
 
-function loadedPaths(messages) {
+function loadedComments(messages) {
   return messages
     .filter((message) => message.name === 'load-danmaku')
-    .map((message) => message.data.path);
+    .map((message) => decodeURIComponent(message.data.xmlContent));
 }
 
 test('switching videos while disabled clears A and loads B when re-enabled', () => {
   const harness = createHarness(true);
   harness.readyOverlay();
   harness.setVideo('file:///videos/A.mp4');
-  assert.deepEqual(loadedPaths(harness.overlayMessages), ['/videos/A.xml']);
+  assert.deepEqual(loadedComments(harness.overlayMessages), ['<i><d p="1,1,25,16777215,0,0,0,0">A comment</d></i>']);
 
   harness.toggleDanmaku();
   const switchStart = harness.overlayMessages.length;
@@ -156,22 +156,25 @@ test('switching videos while disabled clears A and loads B when re-enabled', () 
     1,
     'file-loaded must clear the previous video renderer once even while danmaku is disabled',
   );
-  assert.deepEqual(loadedPaths(duringDisabledSwitch), []);
+  assert.deepEqual(loadedComments(duringDisabledSwitch), []);
   assert.equal(harness.context.currentDanmakuStatus.isLoaded, false);
   assert.equal(harness.context.danmakuFileList.selectedPaths.length, 0);
 
   harness.toggleDanmaku();
-  assert.deepEqual(loadedPaths(harness.overlayMessages), ['/videos/A.xml', '/videos/B.xml']);
+  assert.deepEqual(loadedComments(harness.overlayMessages), [
+    '<i><d p="1,1,25,16777215,0,0,0,0">A comment</d></i>',
+    '<i><d p="1,1,25,16777215,0,0,0,0">B comment</d></i>',
+  ]);
 });
 
 test('enabling after startup-disabled file load initializes that video', () => {
   const harness = createHarness(false);
   harness.readyOverlay();
   harness.setVideo('file:///videos/B.mp4');
-  assert.deepEqual(loadedPaths(harness.overlayMessages), []);
+  assert.deepEqual(loadedComments(harness.overlayMessages), []);
 
   harness.toggleDanmaku();
-  assert.deepEqual(loadedPaths(harness.overlayMessages), ['/videos/B.xml']);
+  assert.deepEqual(loadedComments(harness.overlayMessages), ['<i><d p="1,1,25,16777215,0,0,0,0">B comment</d></i>']);
 });
 
 test('startup-disabled network video stays cleared without starting a match', () => {
@@ -181,7 +184,7 @@ test('startup-disabled network video stays cleared without starting a match', ()
   harness.setVideo('https://example.com/video.m3u8');
 
   assert.ok(harness.overlayMessages.some((message) => message.name === 'clear-danmaku'));
-  assert.deepEqual(loadedPaths(harness.overlayMessages), []);
+  assert.deepEqual(loadedComments(harness.overlayMessages), []);
   assert.deepEqual(harness.httpRequests, []);
 });
 


### PR DESCRIPTION
## Summary
- Remove unused `load-danmaku` payload fields and the redundant startup settings IPC.
- Consolidate Nico JSON filter-state resets and remove duplicate browser-list state.
- Reset overlay timing state when clearing danmaku.
- Remove obsolete CSS and unreachable type-detection code.
- Correct project metadata and documentation, including Dandanplay priority behavior and session-only offsets.

## Verification
- `npm test` — 5/5 passed
- `node --check` passed for all project JavaScript files
- JSON validation passed for `Info.json` and `package.json`
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Canvas rendering now receives the same filtered danmaku content as CSS rendering.
  - Dandanplay network matching now supports network-first or local-first loading based on the selected setting.
  - Plugin descriptions now highlight local files, Dandanplay matching, and CSS/Canvas rendering.

- **Bug Fixes**
  - Danmaku and playback state now reset correctly when clearing or switching videos.
  - Improved consistency when loading, filtering, and displaying danmaku across supported modes.

- **Documentation**
  - Updated README guidance for network loading, caching, session-only timing offsets, and supported rendering behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->